### PR TITLE
develop_Fix: Move turbo to dependencies and use npx for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,24 +8,26 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "turbo run dev",
-    "dev:web": "turbo run dev --filter=web",
-    "dev:server": "turbo run dev --filter=server",
-    "dev:mobile": "turbo run dev --filter=mobile",
-    "build": "turbo run build",
+    "dev": "npx turbo run dev",
+    "dev:web": "npx turbo run dev --filter=web",
+    "dev:server": "npx turbo run dev --filter=server",
+    "dev:mobile": "npx turbo run dev --filter=mobile",
+    "build": "npx turbo run build",
     "build:prod": "npm run build:web && npm run build:server",
-    "build:web": "turbo run build --filter=web",
-    "build:server": "turbo run build --filter=server",
+    "build:web": "npx turbo run build --filter=web",
+    "build:server": "npx turbo run build --filter=server",
     "start": "NODE_ENV=production npm run start --workspace=server",
     "start:prod": "npm run build:prod && npm start",
     "test:prod": "NODE_ENV=production npm run start --workspace=server",
-    "test": "turbo run test",
-    "lint": "turbo run lint",
-    "clean": "turbo run clean"
+    "test": "npx turbo run test",
+    "lint": "npx turbo run lint",
+    "clean": "npx turbo run clean"
+  },
+  "dependencies": {
+    "turbo": "^2.5.5"
   },
   "devDependencies": {
     "@types/node": "^16.18.126",
-    "turbo": "^2.5.5",
     "typescript": "^4.9.5"
   },
   "engines": {


### PR DESCRIPTION
- Moved turbo from devDependencies to dependencies for production builds
- Updated all scripts to use 'npx turbo' instead of 'turbo'
- This ensures turbo is available during Render.com deployment