### PR TITLE
Fix: Add zustand dependency to all packages to resolve deployment errors

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^19.1.0",
     "bootstrap": "^5.3.7",
     "web-vitals": "^2.1.4",
+    "zustand": "^5.0.6",
     "@asset-simulator/shared": "*"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^4.19.2",
+    "zustand": "^5.0.6",
     "@asset-simulator/shared": "*"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "chart.js": "^4.5.0",
     "react-chartjs-2": "^5.3.0",
     "web-vitals": "^2.1.4",
+    "zustand": "^5.0.6",
     "@asset-simulator/shared": "*"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,12 @@
         "apps/*",
         "packages/*"
       ],
+      "dependencies": {
+        "turbo": "^2.5.5",
+        "zustand": "^5.0.6"
+      },
       "devDependencies": {
         "@types/node": "^16.18.126",
-        "turbo": "^2.5.5",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -28,7 +31,8 @@
         "bootstrap": "^5.3.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
@@ -49,7 +53,8 @@
         "@supabase/supabase-js": "^2.52.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",
@@ -69,7 +74,8 @@
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
@@ -17792,7 +17798,6 @@
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.5.tgz",
       "integrity": "sha512-eZ7wI6KjtT1eBqCnh2JPXWNUAxtoxxfi6VdBdZFvil0ychCOTxbm7YLRBi1JSt7U3c+u3CLxpoPxLdvr/Npr3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
@@ -17813,7 +17818,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17827,7 +17831,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17841,7 +17844,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17855,7 +17857,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17869,7 +17870,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17883,7 +17883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "clean": "npx turbo run clean"
   },
   "dependencies": {
-    "turbo": "^2.5.5"
+    "turbo": "^2.5.5",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@types/node": "^16.18.126",


### PR DESCRIPTION
- Added zustand to root package.json for global availability
- Added zustand to apps/web/package.json for web app
- Added zustand to apps/mobile/package.json for mobile app
- Added zustand to apps/server/package.json for server app
- This ensures zustand is available during Render.com deployment build process
- Prevents 'Cannot find module zustand' errors in production builds