### PR TITLE
develop_カレンダー表示機能の追加

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,13 +10,15 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
+    "@asset-simulator/shared": "*",
     "@supabase/supabase-js": "^2.52.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "@types/react-calendar": "^3.9.0",
     "bootstrap": "^5.3.7",
+    "react": "^19.1.0",
+    "react-calendar": "^6.0.0",
+    "react-dom": "^19.1.0",
     "web-vitals": "^2.1.4",
-    "zustand": "^5.0.6",
-    "@asset-simulator/shared": "*"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/apps/mobile/src/MobileApp.tsx
+++ b/apps/mobile/src/MobileApp.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import MobileJournalEntry from './components/MobileJournalEntry';
 import MobileJournalList from './components/MobileJournalList';
+import { JournalCalendar } from './components/JournalCalendar';
 import { useFinancialStore } from './shared/stores/financialStore';
 import './mobile.css';
 
 const MobileApp: React.FC = () => {
-  const [activeTab, setActiveTab] = useState<'entry' | 'list'>('entry');
+  const [activeTab, setActiveTab] = useState<'entry' | 'list' | 'calendar'>('entry');
   const { fetchData } = useFinancialStore();
 
   useEffect(() => {
@@ -31,11 +32,18 @@ const MobileApp: React.FC = () => {
         >
           仕訳履歴
         </button>
+        <button
+          className={`mobile-nav-btn ${activeTab === 'calendar' ? 'active' : ''}`}
+          onClick={() => setActiveTab('calendar')}
+        >
+          カレンダー
+        </button>
       </nav>
 
       <main className="mobile-main">
         {activeTab === 'entry' && <MobileJournalEntry />}
         {activeTab === 'list' && <MobileJournalList />}
+        {activeTab === 'calendar' && <JournalCalendar />}
       </main>
     </div>
   );

--- a/apps/mobile/src/components/JournalCalendar.tsx
+++ b/apps/mobile/src/components/JournalCalendar.tsx
@@ -1,0 +1,483 @@
+import React, { useEffect, useState } from 'react';
+import Calendar, { TileArgs } from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import { useFinancialStore } from '@asset-simulator/shared';
+import type { JournalEntry } from '@asset-simulator/shared';
+
+// カスタムCSS用のインターface
+type CalendarTileProps = TileArgs;
+
+export const JournalCalendar: React.FC = () => {
+  const { journalEntries, journalAccounts, fetchData } = useFinancialStore();
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedDateEntries, setSelectedDateEntries] = useState<JournalEntry[]>([]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // 日付を文字列形式に変換（YYYY-MM-DD）- 時差問題を回避
+  const formatDateToString = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  // 指定した日付の仕訳データを取得
+  const getEntriesForDate = (date: Date): JournalEntry[] => {
+    const dateString = formatDateToString(date);
+    return journalEntries.filter(entry => entry.date === dateString);
+  };
+
+  // 勘定科目名を取得する関数
+  const getAccountName = (accountId: string): string => {
+    const account = journalAccounts.find(acc => acc.id === accountId);
+    return account?.name || '不明';
+  };
+
+  // 勘定科目のカテゴリを取得する関数
+  const getAccountCategory = (accountId: string): string => {
+    const account = journalAccounts.find(acc => acc.id === accountId);
+    return account?.category || '';
+  };
+
+  // 指定した日付の費用・収益を計算
+  const calculateDayFinancials = (date: Date) => {
+    const entries = getEntriesForDate(date);
+    let expenses = 0;
+    let revenues = 0;
+
+    entries.forEach(entry => {
+      const debitCategory = getAccountCategory(entry.debitAccountId);
+      const creditCategory = getAccountCategory(entry.creditAccountId);
+
+      // 借方が費用科目の場合、費用が増加
+      if (debitCategory === 'Expense') {
+        expenses += entry.amount;
+      }
+      // 貸方が費用科目の場合、費用が減少
+      if (creditCategory === 'Expense') {
+        expenses -= entry.amount;
+      }
+      // 借方が収益科目の場合、収益が減少
+      if (debitCategory === 'Revenue') {
+        revenues -= entry.amount;
+      }
+      // 貸方が収益科目の場合、収益が増加
+      if (creditCategory === 'Revenue') {
+        revenues += entry.amount;
+      }
+    });
+
+    return { expenses, revenues };
+  };
+
+  // 日付が選択された時の処理
+  const handleDateChange = (value: any) => {
+    if (value && value instanceof Date) {
+      setSelectedDate(value);
+      const entries = getEntriesForDate(value);
+      setSelectedDateEntries(entries);
+    }
+  };
+
+  // カレンダーのタイルにカスタム内容を表示
+  const tileContent = ({ date, view }: CalendarTileProps) => {
+    if (view === 'month') {
+      const entries = getEntriesForDate(date);
+      const { expenses, revenues } = calculateDayFinancials(date);
+      
+      if (entries.length > 0) {
+        return (
+          <div className="journal-tile-indicator">
+            <div className="entry-count">{entries.length}</div>
+            <div className="entry-amount">
+              {expenses > revenues ? `支出${(expenses / 1000).toFixed(0)}k` : `収益${(revenues / 1000).toFixed(0)}k`}
+            </div>
+          </div>
+        );
+      }
+    }
+    return null;
+  };
+
+  // タイルのクラス名を設定（費用・収益による背景色変更）
+  const tileClassName = ({ date, view }: CalendarTileProps) => {
+    if (view === 'month') {
+      const entries = getEntriesForDate(date);
+      if (entries.length > 0) {
+        const { expenses, revenues } = calculateDayFinancials(date);
+        if (expenses > revenues) {
+          return 'has-entries expense-dominant';
+        } else if (revenues > expenses) {
+          return 'has-entries revenue-dominant';
+        } else {
+          return 'has-entries balanced';
+        }
+      }
+    }
+    return '';
+  };
+
+  return (
+    <div className="journal-calendar-mobile">
+      <style>{`
+        .journal-calendar-mobile {
+          padding: 16px;
+          max-width: 100%;
+          overflow-x: hidden;
+        }
+        
+        .mobile-calendar-header {
+          margin-bottom: 16px;
+          text-align: center;
+        }
+        
+        .mobile-calendar-header h2 {
+          font-size: 1.3em;
+          margin-bottom: 8px;
+          color: #333;
+        }
+        
+        .mobile-calendar-header p {
+          font-size: 0.9em;
+          color: #666;
+          margin: 0;
+        }
+        
+        .react-calendar {
+          width: 100%;
+          border: 1px solid #ddd;
+          border-radius: 8px;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+          font-size: 1em;
+        }
+        
+        .react-calendar__navigation {
+          height: 54px;
+          margin-bottom: 0.5em;
+        }
+        
+        .react-calendar__navigation__label {
+          font-size: 1.1em;
+          font-weight: bold;
+        }
+        
+        .react-calendar__navigation__arrow {
+          font-size: 1.1em;
+        }
+        
+        .react-calendar__month-view__weekdays {
+          text-align: center;
+          text-transform: uppercase;
+          font-weight: bold;
+          font-size: 0.8em;
+          padding: 8px 0;
+        }
+        
+        .react-calendar__tile {
+          height: 65px;
+          position: relative;
+          padding: 4px;
+          font-size: 0.9em;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: flex-start;
+        }
+        
+        .react-calendar__tile.has-entries {
+          border-radius: 4px;
+        }
+        
+        .react-calendar__tile.expense-dominant {
+          background-color: #e3f2fd !important;
+          border: 1px solid #2196f3;
+        }
+        
+        .react-calendar__tile.revenue-dominant {
+          background-color: #ffebee !important;
+          border: 1px solid #f44336;
+        }
+        
+        .react-calendar__tile.balanced {
+          background-color: #f3e5f5 !important;
+          border: 1px solid #9c27b0;
+        }
+        
+        .react-calendar__tile.expense-dominant:hover {
+          background-color: #bbdefb !important;
+        }
+        
+        .react-calendar__tile.revenue-dominant:hover {
+          background-color: #ffcdd2 !important;
+        }
+        
+        .react-calendar__tile.balanced:hover {
+          background-color: #e1bee7 !important;
+        }
+        
+        .journal-tile-indicator {
+          font-size: 9px;
+          position: absolute;
+          bottom: 2px;
+          left: 50%;
+          transform: translateX(-50%);
+          width: 100%;
+          text-align: center;
+        }
+        
+        .entry-count {
+          background-color: #2196f3;
+          color: white;
+          border-radius: 50%;
+          width: 14px;
+          height: 14px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 8px;
+          margin-bottom: 1px;
+        }
+        
+        .entry-amount {
+          color: #1976d2;
+          font-weight: bold;
+          font-size: 8px;
+        }
+        
+        .mobile-selected-date {
+          margin-top: 20px;
+          background: #f8f9fa;
+          border: 1px solid #dee2e6;
+          border-radius: 8px;
+          padding: 16px;
+        }
+        
+        .mobile-selected-date-header {
+          font-size: 1.1em;
+          font-weight: bold;
+          margin-bottom: 12px;
+          color: #495057;
+          text-align: center;
+        }
+        
+        .mobile-journal-entry {
+          background: white;
+          border: 1px solid #e9ecef;
+          border-radius: 6px;
+          padding: 12px;
+          margin-bottom: 8px;
+          box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        
+        .mobile-journal-entry.expense {
+          border-left: 3px solid #2196f3;
+          background: #f8fbff;
+        }
+        
+        .mobile-journal-entry.revenue {
+          border-left: 3px solid #f44336;
+          background: #fffbfb;
+        }
+        
+        .mobile-entry-description {
+          font-weight: bold;
+          color: #495057;
+          margin-bottom: 6px;
+          font-size: 0.95em;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          flex-wrap: wrap;
+        }
+        
+        .mobile-type-badge {
+          font-size: 0.6em;
+          padding: 1px 4px;
+          border-radius: 2px;
+          color: white;
+          font-weight: normal;
+        }
+        
+        .mobile-type-badge.expense {
+          background-color: #2196f3;
+        }
+        
+        .mobile-type-badge.revenue {
+          background-color: #f44336;
+        }
+        
+        .mobile-financial-summary {
+          background: #f8f9fa;
+          border: 1px solid #dee2e6;
+          border-radius: 6px;
+          padding: 10px;
+          margin-bottom: 12px;
+          font-size: 0.9em;
+        }
+        
+        .mobile-summary-item {
+          margin-bottom: 4px;
+          text-align: center;
+        }
+        
+        .mobile-summary-item:last-child {
+          margin-bottom: 0;
+          padding-top: 4px;
+          border-top: 1px solid #dee2e6;
+          font-weight: bold;
+        }
+        
+        .mobile-summary-item.expense span {
+          color: #2196f3;
+        }
+        
+        .mobile-summary-item.revenue span {
+          color: #f44336;
+        }
+        
+        .mobile-summary-item .positive {
+          color: #28a745;
+        }
+        
+        .mobile-summary-item .negative {
+          color: #dc3545;
+        }
+        
+        .mobile-entry-accounts {
+          font-size: 0.85em;
+          margin-bottom: 6px;
+          line-height: 1.3;
+        }
+        
+        .mobile-entry-debit {
+          color: #dc3545;
+          display: block;
+          margin-bottom: 2px;
+        }
+        
+        .mobile-entry-credit {
+          color: #28a745;
+          display: block;
+        }
+        
+        .mobile-entry-amount {
+          font-size: 1em;
+          font-weight: bold;
+          text-align: right;
+          color: #495057;
+        }
+        
+        .mobile-no-entries {
+          text-align: center;
+          color: #6c757d;
+          font-style: italic;
+          padding: 20px;
+          font-size: 0.9em;
+        }
+        
+        .mobile-daily-summary {
+          background: #e9ecef;
+          padding: 10px;
+          border-radius: 4px;
+          text-align: center;
+          font-weight: bold;
+          margin-top: 8px;
+          font-size: 0.95em;
+        }
+      `}</style>
+      
+      <div className="mobile-calendar-header">
+        <h2>📅 仕訳カレンダー</h2>
+        <p>日付をタップしてその日の仕訳を確認</p>
+      </div>
+      
+      <Calendar
+        onChange={handleDateChange}
+        value={selectedDate}
+        tileContent={tileContent}
+        tileClassName={tileClassName}
+        locale="ja-JP"
+      />
+      
+      <div className="mobile-selected-date">
+        <div className="mobile-selected-date-header">
+          {selectedDate.toLocaleDateString('ja-JP', {
+            month: 'long',
+            day: 'numeric',
+            weekday: 'short'
+          })} の仕訳
+        </div>
+        
+        {selectedDateEntries.length === 0 ? (
+          <div className="mobile-no-entries">
+            この日は仕訳データがありません
+          </div>
+        ) : (
+          <div className="mobile-entries-list">
+            {/* 費用・収益サマリー */}
+            {(() => {
+              const { expenses, revenues } = calculateDayFinancials(selectedDate);
+              if (expenses > 0 || revenues > 0) {
+                return (
+                  <div className="mobile-financial-summary">
+                    {expenses > 0 && (
+                      <div className="mobile-summary-item expense">
+                        <span>費用: ¥{expenses.toLocaleString()}</span>
+                      </div>
+                    )}
+                    {revenues > 0 && (
+                      <div className="mobile-summary-item revenue">
+                        <span>収益: ¥{revenues.toLocaleString()}</span>
+                      </div>
+                    )}
+                    <div className="mobile-summary-item net">
+                      <span className={revenues - expenses >= 0 ? 'positive' : 'negative'}>
+                        純損益: ¥{(revenues - expenses).toLocaleString()}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }
+              return null;
+            })()}
+
+            {selectedDateEntries.map((entry) => {
+              const debitCategory = getAccountCategory(entry.debitAccountId);
+              const creditCategory = getAccountCategory(entry.creditAccountId);
+              const isExpenseEntry = debitCategory === 'Expense' || creditCategory === 'Expense';
+              const isRevenueEntry = debitCategory === 'Revenue' || creditCategory === 'Revenue';
+              
+              return (
+                <div key={entry.id} className={`mobile-journal-entry ${isExpenseEntry ? 'expense' : ''} ${isRevenueEntry ? 'revenue' : ''}`}>
+                  <div className="mobile-entry-description">
+                    {entry.description}
+                    {isExpenseEntry && <span className="mobile-type-badge expense">費用</span>}
+                    {isRevenueEntry && <span className="mobile-type-badge revenue">収益</span>}
+                  </div>
+                  <div className="mobile-entry-accounts">
+                    <span className="mobile-entry-debit">
+                      借方: {getAccountName(entry.debitAccountId)}
+                    </span>
+                    <span className="mobile-entry-credit">
+                      貸方: {getAccountName(entry.creditAccountId)}
+                    </span>
+                  </div>
+                  <div className="mobile-entry-amount">
+                    ¥{entry.amount.toLocaleString()}
+                  </div>
+                </div>
+              );
+            })}
+            
+            <div className="mobile-daily-summary">
+              仕訳件数: {selectedDateEntries.length}件
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/mobile/src/mobile.css
+++ b/apps/mobile/src/mobile.css
@@ -47,14 +47,15 @@ body {
 
 .mobile-nav-btn {
   flex: 1;
-  padding: 1rem;
+  padding: 0.8rem 0.5rem;
   background: none;
   border: none;
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 500;
   color: #666;
   transition: all 0.3s ease;
   position: relative;
+  text-align: center;
 }
 
 .mobile-nav-btn.active {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,15 +10,17 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
+    "@asset-simulator/shared": "*",
     "@supabase/supabase-js": "^2.52.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "@types/react-calendar": "^3.9.0",
     "bootstrap": "^5.3.7",
     "chart.js": "^4.5.0",
+    "react": "^19.1.0",
+    "react-calendar": "^6.0.0",
     "react-chartjs-2": "^5.3.0",
+    "react-dom": "^19.1.0",
     "web-vitals": "^2.1.4",
-    "zustand": "^5.0.6",
-    "@asset-simulator/shared": "*"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,12 +7,13 @@ import { CreditCardManager } from './components/CreditCardManager';
 import { JournalAccountManager } from './components/JournalAccountManager';
 import { JournalEntryForm } from './components/JournalEntryForm';
 import { JournalEntryList } from './components/JournalEntryList';
+import { JournalCalendar } from './components/JournalCalendar';
 import { BalanceSheetDisplay } from './components/BalanceSheetDisplay';
 import { ProfitAndLossDisplay } from './components/ProfitAndLossDisplay';
 
 import { useFinancialStore } from './shared';
 
-type Tab = 'dashboard' | 'transactions' | 'masters';
+type Tab = 'dashboard' | 'transactions' | 'calendar' | 'masters';
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>('masters');
@@ -32,6 +33,14 @@ function App() {
             </div>
             <div className="col-lg-7">
               <JournalEntryList />
+            </div>
+          </div>
+        );
+      case 'calendar':
+        return (
+          <div className="row">
+            <div className="col-12">
+              <JournalCalendar />
             </div>
           </div>
         );
@@ -77,6 +86,9 @@ function App() {
         </li>
         <li className="nav-item">
           <button className={`nav-link ${activeTab === 'transactions' ? 'active' : ''}`} onClick={() => setActiveTab('transactions')}>取引入力</button>
+        </li>
+        <li className="nav-item">
+          <button className={`nav-link ${activeTab === 'calendar' ? 'active' : ''}`} onClick={() => setActiveTab('calendar')}>仕訳カレンダー</button>
         </li>
         <li className="nav-item">
           <button className={`nav-link ${activeTab === 'dashboard' ? 'active' : ''}`} onClick={() => setActiveTab('dashboard')}>ダッシュボード</button>

--- a/apps/web/src/components/JournalCalendar.tsx
+++ b/apps/web/src/components/JournalCalendar.tsx
@@ -1,0 +1,523 @@
+import React, { useEffect, useState } from 'react';
+import Calendar, { TileArgs } from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import { useFinancialStore } from '@asset-simulator/shared';
+import type { JournalEntry } from '@asset-simulator/shared';
+
+// カスタムCSS用のインターface
+type CalendarTileProps = TileArgs;
+
+export const JournalCalendar: React.FC = () => {
+  const { journalEntries, journalAccounts, fetchData } = useFinancialStore();
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [selectedDateEntries, setSelectedDateEntries] = useState<JournalEntry[]>([]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // 日付を文字列形式に変換（YYYY-MM-DD）- 時差問題を回避
+  const formatDateToString = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  // 指定した日付の仕訳データを取得
+  const getEntriesForDate = (date: Date): JournalEntry[] => {
+    const dateString = formatDateToString(date);
+    return journalEntries.filter(entry => entry.date === dateString);
+  };
+
+  // 勘定科目名を取得する関数
+  const getAccountName = (accountId: string): string => {
+    const account = journalAccounts.find(acc => acc.id === accountId);
+    return account?.name || '不明';
+  };
+
+  // 勘定科目のカテゴリを取得する関数
+  const getAccountCategory = (accountId: string): string => {
+    const account = journalAccounts.find(acc => acc.id === accountId);
+    return account?.category || '';
+  };
+
+  // 指定した日付の費用・収益を計算
+  const calculateDayFinancials = (date: Date) => {
+    const entries = getEntriesForDate(date);
+    let expenses = 0;
+    let revenues = 0;
+
+    entries.forEach(entry => {
+      const debitCategory = getAccountCategory(entry.debitAccountId);
+      const creditCategory = getAccountCategory(entry.creditAccountId);
+
+      // 借方が費用科目の場合、費用が増加
+      if (debitCategory === 'Expense') {
+        expenses += entry.amount;
+      }
+      // 貸方が費用科目の場合、費用が減少
+      if (creditCategory === 'Expense') {
+        expenses -= entry.amount;
+      }
+      // 借方が収益科目の場合、収益が減少
+      if (debitCategory === 'Revenue') {
+        revenues -= entry.amount;
+      }
+      // 貸方が収益科目の場合、収益が増加
+      if (creditCategory === 'Revenue') {
+        revenues += entry.amount;
+      }
+    });
+
+    return { expenses, revenues };
+  };
+
+  // 日付が選択された時の処理
+  const handleDateChange = (value: any) => {
+    if (value && value instanceof Date) {
+      setSelectedDate(value);
+      const entries = getEntriesForDate(value);
+      setSelectedDateEntries(entries);
+    }
+  };
+
+  // カレンダーのタイルにカスタム内容を表示
+  const tileContent = ({ date, view }: CalendarTileProps) => {
+    if (view === 'month') {
+      const entries = getEntriesForDate(date);
+      const { expenses, revenues } = calculateDayFinancials(date);
+      
+      if (entries.length > 0) {
+        return (
+          <div className="journal-tile-indicator">
+            <div className="entry-count">{entries.length}</div>
+            <div className="entry-financial">
+              {expenses > 0 && <div className="expense-amount">支出: ¥{expenses.toLocaleString()}</div>}
+              {revenues > 0 && <div className="revenue-amount">収益: ¥{revenues.toLocaleString()}</div>}
+            </div>
+          </div>
+        );
+      }
+    }
+    return null;
+  };
+
+  // タイルのクラス名を設定（費用・収益による背景色変更）
+  const tileClassName = ({ date, view }: CalendarTileProps) => {
+    if (view === 'month') {
+      const entries = getEntriesForDate(date);
+      if (entries.length > 0) {
+        const { expenses, revenues } = calculateDayFinancials(date);
+        if (expenses > revenues) {
+          return 'has-entries expense-dominant';
+        } else if (revenues > expenses) {
+          return 'has-entries revenue-dominant';
+        } else {
+          return 'has-entries balanced';
+        }
+      }
+    }
+    return '';
+  };
+
+  return (
+    <div className="journal-calendar-container">
+      <style>{`
+        .journal-calendar-container {
+          padding: 20px;
+        }
+        
+        .calendar-header {
+          margin-bottom: 20px;
+        }
+        
+        .calendar-wrapper {
+          display: flex;
+          gap: 30px;
+          flex-wrap: wrap;
+        }
+        
+        .calendar-section {
+          flex: 2;
+          min-width: 500px;
+        }
+        
+        .entries-section {
+          flex: 1;
+          min-width: 350px;
+        }
+        
+        .react-calendar {
+          border: 1px solid #ddd;
+          border-radius: 8px;
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+          width: 100%;
+          max-width: none;
+          font-size: 1.1em;
+        }
+        
+        .react-calendar__navigation {
+          height: 60px;
+          margin-bottom: 1em;
+        }
+        
+        .react-calendar__navigation__label {
+          font-size: 1.3em;
+          font-weight: bold;
+        }
+        
+        .react-calendar__navigation__arrow {
+          font-size: 1.2em;
+        }
+        
+        .react-calendar__month-view__weekdays {
+          text-align: center;
+          text-transform: uppercase;
+          font-weight: bold;
+          font-size: 0.9em;
+          padding: 10px 0;
+        }
+        
+        .react-calendar__tile {
+          height: 80px;
+          position: relative;
+          padding: 8px;
+          font-size: 1em;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: flex-start;
+        }
+        
+        .react-calendar__tile.has-entries {
+          border-radius: 4px;
+        }
+        
+        .react-calendar__tile.expense-dominant {
+          background-color: #e3f2fd !important;
+          border: 2px solid #2196f3;
+        }
+        
+        .react-calendar__tile.revenue-dominant {
+          background-color: #ffebee !important;
+          border: 2px solid #f44336;
+        }
+        
+        .react-calendar__tile.balanced {
+          background-color: #f3e5f5 !important;
+          border: 2px solid #9c27b0;
+        }
+        
+        .react-calendar__tile.expense-dominant:hover {
+          background-color: #bbdefb !important;
+        }
+        
+        .react-calendar__tile.revenue-dominant:hover {
+          background-color: #ffcdd2 !important;
+        }
+        
+        .react-calendar__tile.balanced:hover {
+          background-color: #e1bee7 !important;
+        }
+        
+        .journal-tile-indicator {
+          font-size: 10px;
+          margin-top: 4px;
+          text-align: center;
+          width: 100%;
+        }
+        
+        .entry-count {
+          background-color: #333;
+          color: white;
+          border-radius: 50%;
+          width: 18px;
+          height: 18px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 0 auto 3px;
+          font-size: 9px;
+        }
+        
+        .entry-financial {
+          line-height: 1.1;
+        }
+        
+        .expense-amount {
+          color: #1976d2;
+          font-weight: bold;
+          font-size: 9px;
+          margin-bottom: 1px;
+        }
+        
+        .revenue-amount {
+          color: #d32f2f;
+          font-weight: bold;
+          font-size: 9px;
+        }
+        
+        .selected-date-section {
+          background: #f8f9fa;
+          border: 1px solid #dee2e6;
+          border-radius: 8px;
+          padding: 20px;
+        }
+        
+        .selected-date-header {
+          font-size: 1.2em;
+          font-weight: bold;
+          margin-bottom: 15px;
+          color: #495057;
+        }
+        
+        .journal-entry-item {
+          background: white;
+          border: 1px solid #e9ecef;
+          border-radius: 6px;
+          padding: 15px;
+          margin-bottom: 10px;
+          box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        
+        .journal-entry-item.expense-entry {
+          border-left: 4px solid #2196f3;
+          background: #f8fbff;
+        }
+        
+        .journal-entry-item.revenue-entry {
+          border-left: 4px solid #f44336;
+          background: #fffbfb;
+        }
+        
+        .entry-description {
+          font-weight: bold;
+          color: #495057;
+          margin-bottom: 8px;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        
+        .entry-type-badge {
+          font-size: 0.7em;
+          padding: 2px 6px;
+          border-radius: 3px;
+          color: white;
+          font-weight: normal;
+        }
+        
+        .entry-type-badge.expense {
+          background-color: #2196f3;
+        }
+        
+        .entry-type-badge.revenue {
+          background-color: #f44336;
+        }
+        
+        .financial-summary {
+          background: #f8f9fa;
+          border: 1px solid #dee2e6;
+          border-radius: 6px;
+          padding: 12px;
+          margin-bottom: 15px;
+        }
+        
+        .summary-item {
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 5px;
+        }
+        
+        .summary-item:last-child {
+          margin-bottom: 0;
+          padding-top: 5px;
+          border-top: 1px solid #dee2e6;
+          font-weight: bold;
+        }
+        
+        .summary-item.expense .summary-amount {
+          color: #2196f3;
+        }
+        
+        .summary-item.revenue .summary-amount {
+          color: #f44336;
+        }
+        
+        .summary-amount.positive {
+          color: #28a745;
+        }
+        
+        .summary-amount.negative {
+          color: #dc3545;
+        }
+        
+        .entry-accounts {
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 8px;
+          font-size: 0.9em;
+        }
+        
+        .entry-debit {
+          color: #dc3545;
+        }
+        
+        .entry-credit {
+          color: #28a745;
+        }
+        
+        .entry-amount {
+          font-size: 1.1em;
+          font-weight: bold;
+          text-align: right;
+          color: #495057;
+        }
+        
+        .no-entries {
+          text-align: center;
+          color: #6c757d;
+          font-style: italic;
+          padding: 20px;
+        }
+        
+        @media (max-width: 1200px) {
+          .calendar-section {
+            flex: 1;
+            min-width: 450px;
+          }
+        }
+        
+        @media (max-width: 768px) {
+          .calendar-wrapper {
+            flex-direction: column;
+          }
+          
+          .calendar-section,
+          .entries-section {
+            min-width: 100%;
+          }
+          
+          .react-calendar__tile {
+            height: 60px;
+            font-size: 0.9em;
+          }
+          
+          .journal-tile-indicator {
+            font-size: 8px;
+          }
+          
+          .entry-count {
+            width: 14px;
+            height: 14px;
+            font-size: 7px;
+          }
+        }
+      `}</style>
+      
+      <div className="calendar-header">
+        <h2>📅 仕訳カレンダー</h2>
+        <p>カレンダーから日付を選択して、その日の仕訳データを確認できます。</p>
+      </div>
+      
+      <div className="calendar-wrapper">
+        <div className="calendar-section">
+          <Calendar
+            onChange={handleDateChange}
+            value={selectedDate}
+            tileContent={tileContent}
+            tileClassName={tileClassName}
+            locale="ja-JP"
+          />
+        </div>
+        
+        <div className="entries-section">
+          <div className="selected-date-section">
+            <div className="selected-date-header">
+              {selectedDate.toLocaleDateString('ja-JP', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                weekday: 'long'
+              })} の仕訳
+            </div>
+            
+            {selectedDateEntries.length === 0 ? (
+              <div className="no-entries">
+                この日は仕訳データがありません
+              </div>
+            ) : (
+              <div className="entries-list">
+                {/* 費用・収益サマリー */}
+                {(() => {
+                  const { expenses, revenues } = calculateDayFinancials(selectedDate);
+                  if (expenses > 0 || revenues > 0) {
+                    return (
+                      <div className="financial-summary">
+                        {expenses > 0 && (
+                          <div className="summary-item expense">
+                            <span className="summary-label">費用合計:</span>
+                            <span className="summary-amount">¥{expenses.toLocaleString()}</span>
+                          </div>
+                        )}
+                        {revenues > 0 && (
+                          <div className="summary-item revenue">
+                            <span className="summary-label">収益合計:</span>
+                            <span className="summary-amount">¥{revenues.toLocaleString()}</span>
+                          </div>
+                        )}
+                        <div className="summary-item net">
+                          <span className="summary-label">純損益:</span>
+                          <span className={`summary-amount ${revenues - expenses >= 0 ? 'positive' : 'negative'}`}>
+                            ¥{(revenues - expenses).toLocaleString()}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  }
+                  return null;
+                })()}
+
+                {/* 仕訳詳細リスト */}
+                {selectedDateEntries.map((entry) => {
+                  const debitCategory = getAccountCategory(entry.debitAccountId);
+                  const creditCategory = getAccountCategory(entry.creditAccountId);
+                  const isExpenseEntry = debitCategory === 'Expense' || creditCategory === 'Expense';
+                  const isRevenueEntry = debitCategory === 'Revenue' || creditCategory === 'Revenue';
+                  
+                  return (
+                    <div key={entry.id} className={`journal-entry-item ${isExpenseEntry ? 'expense-entry' : ''} ${isRevenueEntry ? 'revenue-entry' : ''}`}>
+                      <div className="entry-description">
+                        {entry.description}
+                        {isExpenseEntry && <span className="entry-type-badge expense">費用</span>}
+                        {isRevenueEntry && <span className="entry-type-badge revenue">収益</span>}
+                      </div>
+                      <div className="entry-accounts">
+                        <span className="entry-debit">
+                          借方: {getAccountName(entry.debitAccountId)}
+                        </span>
+                        <span className="entry-credit">
+                          貸方: {getAccountName(entry.creditAccountId)}
+                        </span>
+                      </div>
+                      <div className="entry-amount">
+                        ¥{entry.amount.toLocaleString()}
+                      </div>
+                    </div>
+                  );
+                })}
+                
+                <div className="daily-summary">
+                  <strong>
+                    仕訳件数: {selectedDateEntries.length}件
+                  </strong>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,10 @@
       "dependencies": {
         "@asset-simulator/shared": "*",
         "@supabase/supabase-js": "^2.52.0",
+        "@types/react-calendar": "^3.9.0",
         "bootstrap": "^5.3.7",
         "react": "^19.1.0",
+        "react-calendar": "^6.0.0",
         "react-dom": "^19.1.0",
         "web-vitals": "^2.1.4",
         "zustand": "^5.0.6"
@@ -69,9 +71,11 @@
       "dependencies": {
         "@asset-simulator/shared": "*",
         "@supabase/supabase-js": "^2.52.0",
+        "@types/react-calendar": "^3.9.0",
         "bootstrap": "^5.3.7",
         "chart.js": "^4.5.0",
         "react": "^19.1.0",
+        "react-calendar": "^6.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "web-vitals": "^2.1.4",
@@ -4367,10 +4371,18 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-calendar": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.9.0.tgz",
+      "integrity": "sha512-KpAu1MKAGFw5hNwlDnWsHWqI9i/igAB+8jH97YV7QpC2v7rlwNEU5i6VMFb73lGRacuejM/Zd2LklnEzkFV3XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -4996,6 +5008,15 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+      "integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -6454,6 +6475,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7252,7 +7282,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9616,6 +9645,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-user-locale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -12160,7 +12201,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -12595,7 +12635,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12718,6 +12757,21 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -12808,6 +12862,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -15427,6 +15493,31 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
+      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^2.0.2",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-chartjs-2": {
@@ -18670,6 +18761,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {


### PR DESCRIPTION
Fix: カレンダー機能
- 費用・収益による背景色分けを実装
  - 費用が上回る日: 青色背景
  - 収益が上回る日: 赤色背景
  - 同額の日: 紫色背景
- カレンダータイルに費用・収益情報を表示
- 選択日の詳細に財務サマリーを追加
- 費用・収益仕訳にバッジとボーダーを追加
- モバイル版も同様の機能を実装