### PR TITLE
fix(モバイル): タイトル「取引管理ダッシュボード」を1行に収める (#71)

### DIFF
--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -215,8 +215,8 @@ function App() {
 
   return (
     <main style={{ display: "flex", flexDirection: "column", minHeight: "100vh", background: "#F3F4F6", color: "#111827" }}>
-      <header style={{ display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", padding: "32px 32px 16px", borderBottom: "1px solid #E5E7EB" }}>
-        <h1 style={{ margin: 0, fontSize: 34, marginBottom: 18, color: "#4B5563" }}>取引管理ダッシュボード</h1>
+      <header style={{ display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center", padding: "16px 20px", borderBottom: "1px solid #E5E7EB", gap: 12 }}>
+        <h1 style={{ margin: 0, fontSize: 20, color: "#4B5563", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0 }}>取引管理ダッシュボード</h1>
         <CommonButton label="ログアウト" sizeVariant="S" colorVariant="secondary" onClick={signOut} />
       </header>
       <div style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "hidden", maxHeight: "calc(100vh - 120px)" }}>


### PR DESCRIPTION
## Summary
- `fontSize: 34` → `20` に縮小し、モバイル画面でも1行に収まるよう調整
- `whiteSpace: "nowrap"` + `textOverflow: "ellipsis"` で折り返し禁止
- ヘッダーの `padding` を `32px 32px 16px` → `16px 20px` に縮小してレイアウトをコンパクトに

## Test plan
- [ ] 狭いモバイル画面（375px幅など）でタイトルが1行に収まること
- [ ] タイトルが折り返されないこと

closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)