### PR TITLE
fix(モバイル): 全ページのカードが右に寄ってしまっている (#73)

### DIFF
--- a/mobile/components/Card.tsx
+++ b/mobile/components/Card.tsx
@@ -15,7 +15,8 @@ interface CardBodyProps {
 
 const styles = {
   container: {
-    width: 358,
+    width: "100%",
+    maxWidth: 358,
     borderRadius: 12,
     background: "#FFFFFF",
     boxShadow: "0px 4px 12px rgba(0,0,0,0.08)",

--- a/mobile/components/PanelButton.tsx
+++ b/mobile/components/PanelButton.tsx
@@ -9,7 +9,8 @@ interface PanelButtonProps {
 
 const styles = {
   container: {
-    width: 358,
+    width: "100%",
+    maxWidth: 358,
     borderRadius: 20,
     border: "1px solid #E5E7EB",
     background: "#FFFFFF",


### PR DESCRIPTION
## Summary
- `Card` と `PanelButton` の固定幅 `width: 358` を `maxWidth: 358, width: "100%"` に変更
- モバイル画面ではコンテナ幅に追従し、カードが画面右にはみ出す問題を解消
- PC・タブレットでは従来通り最大 358px

## Test plan
- [ ] 375px 幅のモバイル画面でカードが左寄りに正しく表示されること
- [ ] すべてのタブ（取引・PL/BS・定期取引・勘定科目）でカードがはみ出さないこと
- [ ] 広い画面では変化がないこと

closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)