### PR TITLE
fix(モバイル): 勘定科目マスタに無意味な金額が表示されている (#76)

### DIFF
--- a/mobile/app/src/AccountMasterCard.tsx
+++ b/mobile/app/src/AccountMasterCard.tsx
@@ -92,7 +92,7 @@ export function AccountMasterCard() {
               <div style={{ display: "grid", gap: 2 }}>
                 <div style={{ fontWeight: 700, fontSize: 14 }}>{acc.name}</div>
                 <div style={{ fontSize: 12, color: "#6B7280" }}>
-                  {categoryLabel[acc.category] ?? acc.category} ・ 残高 ¥{acc.balance.toLocaleString()}
+                  {categoryLabel[acc.category] ?? acc.category}
                 </div>
               </div>
               <CommonButton


### PR DESCRIPTION
## Summary
- 勘定科目マスタの各行に表示されていた「残高 ¥X」を削除
- `balance` フィールドはマスタ管理上意味を持たないため、カテゴリ名のみ表示

## Test plan
- [ ] 勘定科目タブを開いて、各科目行に金額が表示されていないこと
- [ ] カテゴリ名（資産・負債・純資産・収益・費用）のみが表示されること

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)