### PR TITLE
fix(モバイル): マージで巻き戻った #71/#74 を復元 + デプロイpaths修正

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'client/**'
+      - 'desktop/**'
+      - 'mobile/app/**'
+      - 'mobile/components/**'
       - 'packages/shared/**'
       - '.github/workflows/deploy-client.yml'
 

--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -215,8 +215,8 @@ function App() {
 
   return (
     <main style={{ display: "flex", flexDirection: "column", height: "100dvh", overflow: "hidden", background: "#F3F4F6", color: "#111827" }}>
-      <header style={{ flexShrink: 0, display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center", padding: "12px 20px", borderBottom: "1px solid #E5E7EB" }}>
-        <h1 style={{ margin: 0, fontSize: 34, color: "#4B5563" }}>取引管理ダッシュボード</h1>
+      <header style={{ flexShrink: 0, display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center", padding: "12px 20px", borderBottom: "1px solid #E5E7EB", gap: 12 }}>
+        <h1 style={{ margin: 0, fontSize: 20, color: "#4B5563", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1, minWidth: 0 }}>取引管理ダッシュボード</h1>
         <CommonButton label="ログアウト" sizeVariant="M" colorVariant="secondary" onClick={signOut} />
       </header>
       <div style={{ flex: 1, overflowY: "auto", padding: 20 }}>
@@ -225,7 +225,7 @@ function App() {
       <nav style={{ flexShrink: 0, display: "flex", flexDirection: "row", overflowX: "auto", borderTop: "1px solid #E5E7EB", background: "#FFFFFF" }}>
         {tabs.map((tab) => (
           <button
-            style={{ padding: "16px 24px", border: "none", borderBottom: activeTab === tab.id ? "3px solid #3B82F6" : "3px solid transparent", background: activeTab === tab.id ? "#EFF6FF" : "transparent", color: activeTab === tab.id ? "#1F2937" : "#6B7280", fontSize: 15, fontWeight: activeTab === tab.id ? 600 : 400, whiteSpace: "nowrap", minWidth: "fit-content", cursor: "pointer", transition: "all 0.2s ease" }}
+            style={{ padding: "20px 24px", minHeight: 60, border: "none", borderBottom: activeTab === tab.id ? "3px solid #3B82F6" : "3px solid transparent", background: activeTab === tab.id ? "#EFF6FF" : "transparent", color: activeTab === tab.id ? "#1F2937" : "#6B7280", fontSize: 15, fontWeight: activeTab === tab.id ? 600 : 400, whiteSpace: "nowrap", minWidth: "fit-content", cursor: "pointer", transition: "all 0.2s ease" }}
             key={tab.id}
             onClick={() => {
               setActiveTab(tab.id);


### PR DESCRIPTION
## 背景
全7件の不具合修正PR(#80-#86)はマージ済みだが、ライブサイトに反映されていないことが判明。調査の結果、原因は2つ。

### 1. 🔴 デプロイがCloudflare認証エラー(401)で失敗（要・別対応）
`Deploy client to Cloudflare Pages` ワークフローは導入以来**一度も成功していない**（公開ステップで `401 Authentication error`）。**`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `CF_PAGES_PROJECT_NAME` の更新が必要**。これはコードでは直せず、本PRの対象外。

### 2. 🟠 マージで #71/#74 のコードが巻き戻っていた（本PRで修正）
#77(タブ固定)ブランチが古いmainから作られ、ヘッダー/navブロックを丸ごと上書きしていたため、マージ時に #71/#74 が消失していた。

## Summary
- **#71**: タイトルを `fontSize: 20` + `nowrap`/`ellipsis` で1行固定（現行の#77レイアウト上に再適用）
- **#74**: タブに `minHeight: 60` + `padding: 20px` を再適用
- **deploy-client.yml**: `paths` に `desktop/**` `mobile/app/**` `mobile/components/**` を追加。client ビルドは `@mobile`/`@web` エイリアスでこれらを取り込むため、従来は mobile/desktop のみの変更でデプロイが発火しなかった

## Test plan
- [ ] （Cloudflare認証修正後）デプロイ成功を確認
- [ ] タイトルが1行で省略表示されること（#71）
- [ ] タブが minHeight 60 で押しやすいこと（#74）
- [ ] mobile配下のみの変更でデプロイワークフローが発火すること

re #71 #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)