### PR TITLE
feat(モバイル): 取引入力をカレンダー日付のダブルタップでダイアログ表示 #75

### DIFF
--- a/mobile/.storybook/Dialog.stories.tsx
+++ b/mobile/.storybook/Dialog.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { useState } from "react";
+import { Dialog } from "../components/Dialog";
+
+const meta = {
+  title: "Components/Dialog",
+  component: Dialog,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  args: { onClose: fn() },
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    title: "2026-06-20 の取引入力",
+    children: <div>ダイアログの本文がここに表示されます。</div>,
+  },
+};
+
+export const Toggle: Story = {
+  args: {
+    isOpen: false,
+    title: "取引入力",
+    children: <div>ダイアログの本文がここに表示されます。</div>,
+  },
+  render: function Render(args) {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setIsOpen(true)}>
+          ダイアログを開く
+        </button>
+        <Dialog {...args} isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      </>
+    );
+  },
+};

--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -14,6 +14,7 @@ import { ProfitLossStatementCard } from "./ProfitLossStatementCard";
 import { BalanceSheetCard } from "./BalanceSheetCard";
 import { PanelButton } from "@mobile-components/PanelButton";
 import { CommonButton } from "@mobile-components/CommonButton";
+import { Dialog } from "@mobile-components/Dialog";
 import LoginScreen from "./LoginScreen";
 
 type TabId = "transaction" | "pl-bs" | "recurring" | "accounts";
@@ -86,6 +87,7 @@ function App() {
 
   const [activeTab, setActiveTab] = useState<TabId>("transaction");
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [entryDialogDate, setEntryDialogDate] = useState<string | null>(null);
   const [entriesVersion, setEntriesVersion] = useState(0);
 
   const [plStartDate, setPlStartDate] = useState(defaults.plStart);
@@ -145,19 +147,21 @@ function App() {
     setSelectedDate(date);
   };
 
+  const handleDateDoubleClick = (date: string) => {
+    setEntryDialogDate(date);
+  };
+
   const renderContent = () => {
     switch (activeTab) {
       case "transaction":
         return (
           <div style={{ display: "grid", gap: 24 }}>
-            <CalendarCard onDateSelect={handleDateSelect} refreshSignal={entriesVersion} onEntryChanged={() => setEntriesVersion((v) => v + 1)} />
-            {selectedDate && (
-              <TransactionEntryCard
-                key={selectedDate}
-                selectedDate={selectedDate}
-                onEntryAdded={() => setEntriesVersion((v) => v + 1)}
-              />
-            )}
+            <CalendarCard
+              onDateSelect={handleDateSelect}
+              onDateDoubleClick={handleDateDoubleClick}
+              refreshSignal={entriesVersion}
+              onEntryChanged={() => setEntriesVersion((v) => v + 1)}
+            />
           </div>
         );
       case "pl-bs":
@@ -236,6 +240,19 @@ function App() {
           </button>
         ))}
       </nav>
+      <Dialog
+        isOpen={entryDialogDate != null}
+        onClose={() => setEntryDialogDate(null)}
+        title="取引入力"
+      >
+        {entryDialogDate && (
+          <TransactionEntryCard
+            key={entryDialogDate}
+            selectedDate={entryDialogDate}
+            onEntryAdded={() => setEntriesVersion((v) => v + 1)}
+          />
+        )}
+      </Dialog>
     </main>
   );
 }

--- a/mobile/components/Dialog.tsx
+++ b/mobile/components/Dialog.tsx
@@ -1,0 +1,103 @@
+import { type CSSProperties, type ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
+
+interface DialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children?: ReactNode;
+}
+
+const styles = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    background: "rgba(15, 23, 42, 0.45)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 16,
+    zIndex: 1000,
+  } satisfies CSSProperties,
+  panel: {
+    width: "100%",
+    maxWidth: 400,
+    maxHeight: "90dvh",
+    overflowY: "auto",
+    borderRadius: 16,
+    background: "#FFFFFF",
+    boxShadow: "0 20px 48px rgba(15, 23, 42, 0.24)",
+    boxSizing: "border-box",
+  } satisfies CSSProperties,
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "16px 20px",
+    borderBottom: "1px solid #E5E7EB",
+  } satisfies CSSProperties,
+  title: {
+    fontSize: 16,
+    fontWeight: 700,
+    color: "#111827",
+    margin: 0,
+  } satisfies CSSProperties,
+  close: {
+    border: "none",
+    background: "transparent",
+    fontSize: 22,
+    lineHeight: 1,
+    color: "#6B7280",
+    cursor: "pointer",
+    padding: 4,
+  } satisfies CSSProperties,
+  body: {
+    padding: 20,
+  } satisfies CSSProperties,
+};
+
+export function Dialog({ isOpen, onClose, title, children }: DialogProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      style={styles.overlay}
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        style={styles.panel}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        {title && (
+          <div style={styles.header}>
+            <h2 style={styles.title}>{title}</h2>
+            <button
+              type="button"
+              style={styles.close}
+              onClick={onClose}
+              aria-label="閉じる"
+            >
+              ×
+            </button>
+          </div>
+        )}
+        <div style={styles.body}>{children}</div>
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## 概要

Issue #75 対応。モバイルの取引入力方法を変更。

- **修正前**: カレンダーの日付を押下 → 画面下にインラインの取引入力フォームが表示される
- **修正後**: カレンダーの日付を**ダブルタップ** → 取引入力ダイアログが表示される

## 変更内容

- `mobile/components/Dialog.tsx` を新規追加
  - `createPortal` で `document.body` に描画するモーダル
  - 背景クリック / Escape キー / × ボタンで閉じる
  - `role="dialog"` / `aria-modal` 付与
- `mobile/app/src/App.tsx`
  - カレンダーの `onDateDoubleClick` を結線し、ダブルタップで取引入力ダイアログを開く
  - 単一クリック時のインラインフォーム表示を廃止（単一クリックは日付選択・取引一覧の閲覧のみ）
- `mobile/.storybook/Dialog.stories.tsx` を追加

## 確認

- [x] `npm run build`（tsc -b && vite build）成功
- [x] `npx eslint` 成功

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)