### PR TITLE
feat(モバイル): 取引の編集を新規登録と同じダイアログで行う

### DIFF
--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -4,7 +4,7 @@ import {
   useFinancialStore,
   useEventsStore,
 } from "@asset-simulator/shared";
-import type { ProfitLossView, BalanceSheetView } from "@asset-simulator/shared";
+import type { ProfitLossView, BalanceSheetView, CalendarJournalEntry } from "@asset-simulator/shared";
 import "./App.css";
 import CalendarCard from "./CalendarCard";
 import TransactionEntryCard from "./TransactionEntryCard";
@@ -88,6 +88,7 @@ function App() {
   const [activeTab, setActiveTab] = useState<TabId>("transaction");
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [entryDialogDate, setEntryDialogDate] = useState<string | null>(null);
+  const [editingEntry, setEditingEntry] = useState<CalendarJournalEntry | null>(null);
   const [entriesVersion, setEntriesVersion] = useState(0);
 
   const [plStartDate, setPlStartDate] = useState(defaults.plStart);
@@ -148,7 +149,18 @@ function App() {
   };
 
   const handleDateDoubleClick = (date: string) => {
+    setEditingEntry(null);
     setEntryDialogDate(date);
+  };
+
+  const handleEditEntry = (entry: CalendarJournalEntry) => {
+    setEntryDialogDate(null);
+    setEditingEntry(entry);
+  };
+
+  const closeEntryDialog = () => {
+    setEntryDialogDate(null);
+    setEditingEntry(null);
   };
 
   const renderContent = () => {
@@ -159,6 +171,7 @@ function App() {
             <CalendarCard
               onDateSelect={handleDateSelect}
               onDateDoubleClick={handleDateDoubleClick}
+              onEditEntry={handleEditEntry}
               refreshSignal={entriesVersion}
               onEntryChanged={() => setEntriesVersion((v) => v + 1)}
             />
@@ -241,17 +254,26 @@ function App() {
         ))}
       </nav>
       <Dialog
-        isOpen={entryDialogDate != null}
-        onClose={() => setEntryDialogDate(null)}
-        title="取引入力"
+        isOpen={entryDialogDate != null || editingEntry != null}
+        onClose={closeEntryDialog}
+        title={editingEntry ? "取引編集" : "取引入力"}
       >
-        {entryDialogDate && (
+        {editingEntry ? (
+          <TransactionEntryCard
+            key={editingEntry.id}
+            entry={editingEntry}
+            onEntryUpdated={() => {
+              setEntriesVersion((v) => v + 1);
+              closeEntryDialog();
+            }}
+          />
+        ) : entryDialogDate ? (
           <TransactionEntryCard
             key={entryDialogDate}
             selectedDate={entryDialogDate}
             onEntryAdded={() => setEntriesVersion((v) => v + 1)}
           />
-        )}
+        ) : null}
       </Dialog>
     </main>
   );

--- a/mobile/app/src/CalendarCard.tsx
+++ b/mobile/app/src/CalendarCard.tsx
@@ -2,14 +2,13 @@ import { useEffect, useMemo, useState } from "react";
 import { useFinancialStore } from "@asset-simulator/shared";
 import type { CalendarJournalEntry } from "@asset-simulator/shared";
 import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
-import { TextInput } from "@mobile-components/TextInput";
-import { SelectInput } from "@mobile-components/SelectInput";
-import { NumericInput } from "@mobile-components/NumericInput";
 import { CommonButton } from "@mobile-components/CommonButton";
 
 interface CalendarCardProps {
   onDateDoubleClick?: (date: string) => void;
   onDateSelect?: (date: string) => void;
+  /** 取引リストの「編集」押下時に呼ばれる（新規入力と同じダイアログで編集する） */
+  onEditEntry?: (entry: CalendarJournalEntry) => void;
   /** 値が変わると当月の取引を再取得する（取引登録後の即時反映用） */
   refreshSignal?: number;
   onEntryChanged?: () => void;
@@ -36,13 +35,9 @@ function getWeekdayLabels() {
   return ["日", "月", "火", "水", "木", "金", "土"];
 }
 
-const PLACEHOLDER = { label: "選択してください", value: "" };
-
-export default function CalendarCard({ onDateDoubleClick, onDateSelect, refreshSignal, onEntryChanged }: CalendarCardProps) {
+export default function CalendarCard({ onDateDoubleClick, onDateSelect, onEditEntry, refreshSignal, onEntryChanged }: CalendarCardProps) {
   const getCalendarJournalEntries = useFinancialStore((s) => s.getCalendarJournalEntries);
-  const updateJournalEntry = useFinancialStore((s) => s.updateJournalEntry);
   const deleteJournalEntry = useFinancialStore((s) => s.deleteJournalEntry);
-  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
 
   const [monthOffset, setMonthOffset] = useState(0);
   const today = new Date();
@@ -52,18 +47,6 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, refreshS
 
   const monthStart = fmt(new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1));
   const monthEnd = fmt(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0));
-
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editDescription, setEditDescription] = useState("");
-  const [editDebitAccountId, setEditDebitAccountId] = useState("");
-  const [editCreditAccountId, setEditCreditAccountId] = useState("");
-  const [editAmount, setEditAmount] = useState(0);
-  const [saving, setSaving] = useState(false);
-
-  const accountOptions = useMemo(
-    () => [PLACEHOLDER, ...journalAccounts.map((acc) => ({ label: acc.name, value: acc.id }))],
-    [journalAccounts]
-  );
 
   const refreshEntries = async () => {
     const rows = await getCalendarJournalEntries(monthStart, monthEnd);
@@ -96,48 +79,6 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, refreshS
     () => entries.filter((e) => e.date === selected),
     [entries, selected]
   );
-
-  const startEdit = (entry: CalendarJournalEntry) => {
-    setEditingId(entry.id);
-    setEditDescription(entry.description);
-    setEditDebitAccountId(entry.debitAccountId);
-    setEditCreditAccountId(entry.creditAccountId);
-    setEditAmount(entry.amount);
-  };
-
-  const cancelEdit = () => {
-    setEditingId(null);
-  };
-
-  const handleUpdate = async (entry: CalendarJournalEntry) => {
-    if (!editDebitAccountId || !editCreditAccountId || editDebitAccountId === editCreditAccountId) {
-      alert("借方・貸方に異なる勘定科目を選択してください");
-      return;
-    }
-    if (!editAmount || editAmount <= 0) {
-      alert("金額を正しく入力してください");
-      return;
-    }
-    setSaving(true);
-    try {
-      await updateJournalEntry({
-        id: entry.id,
-        date: entry.date,
-        description: editDescription,
-        debitAccountId: editDebitAccountId,
-        creditAccountId: editCreditAccountId,
-        amount: editAmount,
-        user_id: entry.userId,
-      });
-      setEditingId(null);
-      await refreshEntries();
-      onEntryChanged?.();
-    } catch {
-      alert("更新に失敗しました");
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const handleDelete = async (entry: CalendarJournalEntry) => {
     if (!confirm("この取引を削除しますか？")) return;
@@ -236,7 +177,6 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, refreshS
                 onClick={() => {
                   setSelectedDate(iso);
                   onDateSelect?.(iso);
-                  setEditingId(null);
                 }}
                 onDoubleClick={() => onDateDoubleClick?.(iso)}
                 style={{
@@ -269,63 +209,32 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, refreshS
         </div>
         <div style={{ marginTop: 16, fontSize: 14, color: "#4B5563" }}>
           {filteredEntries.length === 0 ? (
-            <div style={{ color: "#9CA3AF", fontSize: 13 }}>この日の取引はありません。下の「取引入力」から登録できます。</div>
+            <div style={{ color: "#9CA3AF", fontSize: 13 }}>この日の取引はありません。日付をダブルタップして登録できます。</div>
           ) : (
             <div style={{ display: "grid", gap: 8 }}>
-              {filteredEntries.map((entry) =>
-                editingId === entry.id ? (
-                  <div
-                    key={entry.id}
-                    style={{
-                      border: "1.5px solid #3B82F6",
-                      borderRadius: 8,
-                      padding: 12,
-                      display: "grid",
-                      gap: 8,
-                      background: "#F0F7FF",
-                    }}
-                  >
-                    <TextInput placeholder="摘要" value={editDescription} onChange={setEditDescription} sizeVariant="Full" />
-                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                        <div style={{ fontSize: 12, color: "#6B7280" }}>借方</div>
-                        <SelectInput options={accountOptions} value={editDebitAccountId} onChange={setEditDebitAccountId} sizeVariant="S" />
-                      </div>
-                      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                        <div style={{ fontSize: 12, color: "#6B7280" }}>貸方</div>
-                        <SelectInput options={accountOptions} value={editCreditAccountId} onChange={setEditCreditAccountId} sizeVariant="S" />
-                      </div>
-                      <NumericInput value={editAmount} unit="円" onBlur={setEditAmount} sizeVariant="M" />
-                    </div>
-                    <div style={{ display: "flex", gap: 8 }}>
-                      <CommonButton label={saving ? "保存中..." : "保存"} sizeVariant="M" onClick={() => handleUpdate(entry)} />
-                      <CommonButton label="キャンセル" sizeVariant="M" colorVariant="secondary" onClick={cancelEdit} />
-                    </div>
+              {filteredEntries.map((entry) => (
+                <div
+                  key={entry.id}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    padding: "8px 4px",
+                    borderBottom: "1px solid #F3F4F6",
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 600, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.description}</div>
+                    <div style={{ color: "#6B7280", fontSize: 12 }}>{entry.debitAccountName} → {entry.creditAccountName}</div>
+                    <div style={{ color: "#374151", fontSize: 13 }}>¥{entry.amount.toLocaleString()}</div>
                   </div>
-                ) : (
-                  <div
-                    key={entry.id}
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      gap: 8,
-                      padding: "8px 4px",
-                      borderBottom: "1px solid #F3F4F6",
-                    }}
-                  >
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontWeight: 600, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.description}</div>
-                      <div style={{ color: "#6B7280", fontSize: 12 }}>{entry.debitAccountName} → {entry.creditAccountName}</div>
-                      <div style={{ color: "#374151", fontSize: 13 }}>¥{entry.amount.toLocaleString()}</div>
-                    </div>
-                    <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
-                      <CommonButton label="編集" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => startEdit(entry)} />
-                      <CommonButton label="削除" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => handleDelete(entry)} />
-                    </div>
+                  <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+                    <CommonButton label="編集" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => onEditEntry?.(entry)} />
+                    <CommonButton label="削除" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => handleDelete(entry)} />
                   </div>
-                )
-              )}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/mobile/app/src/TransactionEntryCard.tsx
+++ b/mobile/app/src/TransactionEntryCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useFinancialStore } from "@asset-simulator/shared";
+import type { CalendarJournalEntry } from "@asset-simulator/shared";
 import { Card, CardBodyMain } from "@mobile-components/Card";
 import { DateInput } from "@mobile-components/DateInput";
 import { TextInput } from "@mobile-components/TextInput";
@@ -9,22 +10,35 @@ import { CommonButton } from "@mobile-components/CommonButton";
 
 interface TransactionEntryCardProps {
   selectedDate?: string | null;
+  /** 指定された場合は編集モードになり、登録の代わりに更新を行う */
+  entry?: CalendarJournalEntry | null;
   onEntryAdded?: () => void;
+  onEntryUpdated?: () => void;
 }
 
 const PLACEHOLDER = { label: "選択してください", value: "" };
 
-export default function TransactionEntryCard({ selectedDate, onEntryAdded }: TransactionEntryCardProps) {
+export default function TransactionEntryCard({
+  selectedDate,
+  entry,
+  onEntryAdded,
+  onEntryUpdated,
+}: TransactionEntryCardProps) {
   const journalAccounts = useFinancialStore((s) => s.journalAccounts);
   const addJournalEntry = useFinancialStore((s) => s.addJournalEntry);
+  const updateJournalEntry = useFinancialStore((s) => s.updateJournalEntry);
   const getJournalAccounts = useFinancialStore((s) => s.getJournalAccounts);
 
+  const isEditMode = entry != null;
+
   const [isExpanded, setIsExpanded] = useState(true);
-  const [date, setDate] = useState(() => selectedDate ?? new Date().toLocaleDateString("sv-SE"));
-  const [description, setDescription] = useState("");
-  const [debitAccountId, setDebitAccountId] = useState("");
-  const [creditAccountId, setCreditAccountId] = useState("");
-  const [amount, setAmount] = useState(0);
+  const [date, setDate] = useState(
+    () => entry?.date ?? selectedDate ?? new Date().toLocaleDateString("sv-SE")
+  );
+  const [description, setDescription] = useState(() => entry?.description ?? "");
+  const [debitAccountId, setDebitAccountId] = useState(() => entry?.debitAccountId ?? "");
+  const [creditAccountId, setCreditAccountId] = useState(() => entry?.creditAccountId ?? "");
+  const [amount, setAmount] = useState(() => entry?.amount ?? 0);
   const [submitting, setSubmitting] = useState(false);
   const [count, setCount] = useState(0);
 
@@ -33,27 +47,32 @@ export default function TransactionEntryCard({ selectedDate, onEntryAdded }: Tra
     [journalAccounts]
   );
 
-  const registerEntry = async () => {
+  const validate = () => {
     if (!date) {
       alert("日付を入力してください");
-      return;
+      return false;
     }
     if (!description) {
       alert("摘要を入力してください");
-      return;
+      return false;
     }
     if (!debitAccountId) {
       alert("借方勘定科目を選択してください");
-      return;
+      return false;
     }
     if (!creditAccountId || creditAccountId === debitAccountId) {
       alert("貸方勘定科目を選択してください（借方と異なる科目）");
-      return;
+      return false;
     }
     if (!amount || amount <= 0) {
       alert("金額を正しく入力してください");
-      return;
+      return false;
     }
+    return true;
+  };
+
+  const registerEntry = async () => {
+    if (!validate()) return;
 
     setSubmitting(true);
     try {
@@ -72,10 +91,35 @@ export default function TransactionEntryCard({ selectedDate, onEntryAdded }: Tra
     }
   };
 
+  const updateEntry = async () => {
+    if (!entry || !validate()) return;
+
+    setSubmitting(true);
+    try {
+      await updateJournalEntry({
+        id: entry.id,
+        date,
+        description,
+        debitAccountId,
+        creditAccountId,
+        amount,
+        user_id: entry.userId,
+      });
+      // 変更したリソースのみリフレッシュ（勘定科目の残高更新）
+      await getJournalAccounts();
+      onEntryUpdated?.();
+    } catch (error) {
+      console.error("Failed to update journal entry:", error);
+      alert("取引の更新に失敗しました。通信を確認してください。");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <Card
-      title={`${date} の取引入力`}
-      subInfo={`${count} 件登録済み`}
+      title={isEditMode ? `${date} の取引編集` : `${date} の取引入力`}
+      subInfo={isEditMode ? undefined : `${count} 件登録済み`}
       isExpanded={isExpanded}
       onToggle={() => setIsExpanded((prev) => !prev)}
     >
@@ -117,9 +161,17 @@ export default function TransactionEntryCard({ selectedDate, onEntryAdded }: Tra
             />
           </div>
           <CommonButton
-            label={submitting ? "登録中..." : "登録"}
+            label={
+              isEditMode
+                ? submitting
+                  ? "更新中..."
+                  : "更新"
+                : submitting
+                  ? "登録中..."
+                  : "登録"
+            }
             sizeVariant="S"
-            onClick={registerEntry}
+            onClick={isEditMode ? updateEntry : registerEntry}
           />
         </div>
       </CardBodyMain>


### PR DESCRIPTION
## 概要

取引リストの「編集」を、新規登録（#75）と同じ取引入力ダイアログで行うように統一しました。

- **修正前**: 取引リストの「編集」は、リスト内に展開されるインライン編集フォームで行っていた
- **修正後**: 「編集」押下で新規登録と同じダイアログが**編集モード**で開き、内容を更新する

## 変更内容

- `mobile/app/src/TransactionEntryCard.tsx`
  - `entry` プロップを追加。指定時は編集モードとなり、各項目を初期値として表示し、登録の代わりに `updateJournalEntry` で更新する
  - ボタン表記を編集時は「更新」に切り替え。更新成功で `onEntryUpdated` を通知
- `mobile/app/src/CalendarCard.tsx`
  - インライン編集フォーム（および関連 state / 入力コンポーネント）を撤去
  - 「編集」押下で `onEditEntry(entry)` を呼ぶだけに変更
- `mobile/app/src/App.tsx`
  - `editingEntry` state を追加し、カレンダーの編集をダイアログ（編集モード）に結線
  - 新規入力（ダブルタップ）と編集で同一の `Dialog` + `TransactionEntryCard` を共用

## 確認

- [x] `npm run build`（tsc -b && vite build）成功
- [x] `npx eslint` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)