### PR TITLE
fix(モバイル): UI不具合まとめ修正（初回ズーム/摘要幅/登録後クローズ/サマリーソート/期間即時反映）

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Asset Simulator</title>
   </head>
   <body>

--- a/mobile/app/index.html
+++ b/mobile/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>web-new</title>
   </head>
   <body>

--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -271,7 +271,10 @@ function App() {
           <TransactionEntryCard
             key={entryDialogDate}
             selectedDate={entryDialogDate}
-            onEntryAdded={() => setEntriesVersion((v) => v + 1)}
+            onEntryAdded={() => {
+              setEntriesVersion((v) => v + 1);
+              closeEntryDialog();
+            }}
           />
         ) : null}
       </Dialog>

--- a/mobile/app/src/BalanceSheetCard.tsx
+++ b/mobile/app/src/BalanceSheetCard.tsx
@@ -18,6 +18,9 @@ function fmt(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+// 区分の表示順（貸借対照表: 資産→負債→純資産）
+const CATEGORY_ORDER: Record<string, number> = { Asset: 0, Liability: 1, Equity: 2 };
+
 function getDatePresets() {
   const now = new Date();
   const y = now.getFullYear();
@@ -31,11 +34,17 @@ function getDatePresets() {
 
 export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [pendingDate, setPendingDate] = useState(appliedAsOfDate);
 
-  // サーバー集計済みの BalanceSheetView を表示用の行へマッピング
+  // サーバー集計済みの BalanceSheetView を表示用の行へマッピング（区分→勘定科目でソート）
   const grouped = useMemo(
-    () => rows.map((row) => ({ account: row.name, category: row.category, amount: row.sumAmount })),
+    () =>
+      rows
+        .map((row) => ({ account: row.name, category: row.category, amount: row.sumAmount }))
+        .sort(
+          (a, b) =>
+            (CATEGORY_ORDER[a.category] ?? 99) - (CATEGORY_ORDER[b.category] ?? 99) ||
+            a.account.localeCompare(b.account, "ja")
+        ),
     [rows]
   );
 
@@ -50,7 +59,6 @@ export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
   const presets = getDatePresets();
 
   const applyPreset = (date: string) => {
-    setPendingDate(date);
     onApply(date);
   };
 
@@ -69,8 +77,7 @@ export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
             <CommonButton label="先月末" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.lastMonthEnd)} />
           </div>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-            <DateInput value={pendingDate} onChange={setPendingDate} sizeVariant="M" />
-            <CommonButton label="基準日反映" onClick={() => onApply(pendingDate)} />
+            <DateInput value={appliedAsOfDate} onChange={(v: string) => onApply(v)} sizeVariant="M" />
           </div>
         </div>
       </CardBodyHead>

--- a/mobile/app/src/CalendarCard.tsx
+++ b/mobile/app/src/CalendarCard.tsx
@@ -224,9 +224,9 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, onEditEn
                     borderBottom: "1px solid #F3F4F6",
                   }}
                 >
-                  <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
                     <div style={{ fontWeight: 600, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.description}</div>
-                    <div style={{ color: "#6B7280", fontSize: 12 }}>{entry.debitAccountName} → {entry.creditAccountName}</div>
+                    <div style={{ color: "#6B7280", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.debitAccountName} → {entry.creditAccountName}</div>
                     <div style={{ color: "#374151", fontSize: 13 }}>¥{entry.amount.toLocaleString()}</div>
                   </div>
                   <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>

--- a/mobile/app/src/ProfitLossStatementCard.tsx
+++ b/mobile/app/src/ProfitLossStatementCard.tsx
@@ -19,6 +19,9 @@ function fmt(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+// 区分の表示順（損益計算書: 収益→費用）
+const CATEGORY_ORDER: Record<string, number> = { Revenue: 0, Expense: 1 };
+
 function getPeriodPresets() {
   const now = new Date();
   const y = now.getFullYear();
@@ -34,12 +37,17 @@ function getPeriodPresets() {
 
 export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows, onApply }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [pendingStart, setPendingStart] = useState(appliedStartDate);
-  const [pendingEnd, setPendingEnd] = useState(appliedEndDate);
 
-  // サーバー集計済みの ProfitLossView を表示用の行へマッピング
+  // サーバー集計済みの ProfitLossView を表示用の行へマッピング（区分→勘定科目でソート）
   const grouped = useMemo(
-    () => rows.map((row) => ({ account: row.name, category: row.category, amount: row.sumAmount })),
+    () =>
+      rows
+        .map((row) => ({ account: row.name, category: row.category, amount: row.sumAmount }))
+        .sort(
+          (a, b) =>
+            (CATEGORY_ORDER[a.category] ?? 99) - (CATEGORY_ORDER[b.category] ?? 99) ||
+            a.account.localeCompare(b.account, "ja")
+        ),
     [rows]
   );
 
@@ -56,8 +64,6 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
   const presets = getPeriodPresets();
 
   const applyPreset = (start: string, end: string) => {
-    setPendingStart(start);
-    setPendingEnd(end);
     onApply(start, end);
   };
 
@@ -77,10 +83,9 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
             <CommonButton label="今年" fontSize="S" sizeVariant="S" colorVariant="secondary" onClick={() => applyPreset(...presets.thisYear)} />
           </div>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-            <DateInput value={pendingStart} onChange={setPendingStart} sizeVariant="S" />
+            <DateInput value={appliedStartDate} onChange={(v: string) => onApply(v, appliedEndDate)} sizeVariant="S" />
             <span style={{ alignSelf: "center", color: "#6B7280" }}>〜</span>
-            <DateInput value={pendingEnd} onChange={setPendingEnd} sizeVariant="S" />
-            <CommonButton label="期間反映" onClick={() => onApply(pendingStart, pendingEnd)} />
+            <DateInput value={appliedEndDate} onChange={(v: string) => onApply(appliedStartDate, v)} sizeVariant="S" />
           </div>
         </div>
       </CardBodyHead>


### PR DESCRIPTION
## 関連Issue

closes #91

## 変更概要

モバイル版の UI 不具合 5 件をまとめて修正。

1. **初回ズーム** — `client/index.html` / `mobile/app/index.html` の viewport に `maximum-scale=1.0, user-scalable=no, viewport-fit=cover` を追加し、初回起動時に等倍で表示されるようにした。
2. **摘要オーバーフロー** — `CalendarCard` の取引リストで、テキスト列に `overflow: hidden` を追加し、科目名行にも ellipsis を適用。摘要が長くても「編集」「削除」ボタンがはみ出さない。
3. **登録後にダイアログが閉じない** — `App.tsx` の新規登録 `onEntryAdded` で `closeEntryDialog()` を呼び、編集時と同様に成功時に自動で閉じるようにした。
4. **サマリー未ソート** — `BalanceSheetCard` / `ProfitLossStatementCard` のサマリーリストを区分（BS: 資産→負債→純資産 / PL: 収益→費用）→勘定科目名の順でソート。
5. **期間が即時反映されない** — BS の基準日 / PL の開始・終了日を変更した時点で `onApply` を呼び即時反映。手動の「基準日反映」「期間反映」ボタンは廃止。

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない（既存の `@mobile-components` エイリアス未解決による tsc エラーは本PR対象外・origin/main と同数。`vite build` は成功）
- [x] 影響範囲の動作確認済み（`vite build` 通過 / モバイル取引・PL/BS 画面）
