### PR TITLE
fix(モバイル): 摘要の最大幅と金額入力(空欄/マイナス対応) #91

### DIFF
--- a/mobile/app/src/CalendarCard.tsx
+++ b/mobile/app/src/CalendarCard.tsx
@@ -224,7 +224,7 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, onEditEn
                     borderBottom: "1px solid #F3F4F6",
                   }}
                 >
-                  <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+                  <div style={{ flex: 1, minWidth: 0, maxWidth: "calc(100% - 140px)", overflow: "hidden" }}>
                     <div style={{ fontWeight: 600, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.description}</div>
                     <div style={{ color: "#6B7280", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.debitAccountName} → {entry.creditAccountName}</div>
                     <div style={{ color: "#374151", fontSize: 13 }}>¥{entry.amount.toLocaleString()}</div>

--- a/mobile/app/src/TransactionEntryCard.tsx
+++ b/mobile/app/src/TransactionEntryCard.tsx
@@ -64,8 +64,8 @@ export default function TransactionEntryCard({
       alert("貸方勘定科目を選択してください（借方と異なる科目）");
       return false;
     }
-    if (!amount || amount <= 0) {
-      alert("金額を正しく入力してください");
+    if (!amount) {
+      alert("金額を入力してください（0 以外）");
       return false;
     }
     return true;
@@ -156,6 +156,8 @@ export default function TransactionEntryCard({
             <NumericInput
               value={amount}
               unit="円"
+              placeholder="0"
+              allowNegative
               onBlur={setAmount}
               sizeVariant="M"
             />

--- a/mobile/components/NumericInput.tsx
+++ b/mobile/components/NumericInput.tsx
@@ -29,6 +29,10 @@ interface NumericInputProps {
   min?: number;
   max?: number;
   error?: string;
+  /** 表示用プレースホルダー。指定すると value が 0 のとき入力欄を空にして背面テキストを表示する */
+  placeholder?: string;
+  /** マイナス値の入力を許可する（モバイル向けに符号反転ボタンを表示） */
+  allowNegative?: boolean;
   onBlur?: (value: number) => void;
   sizeVariant?: SizeVariant;
   fontSize?: FontSizeVariant;
@@ -67,6 +71,18 @@ const styles = {
     color: "#666",
     whiteSpace: "nowrap",
   } satisfies CSSProperties,
+  signButton: {
+    flexShrink: 0,
+    width: 36,
+    alignSelf: "stretch",
+    borderRadius: 8,
+    border: "1px solid #D1D5DB",
+    backgroundColor: "#F9FAFB",
+    color: "#374151",
+    fontSize: 18,
+    fontWeight: 700,
+    cursor: "pointer",
+  } satisfies CSSProperties,
   errorText: {
     fontSize: 12,
     color: "#DC2626",
@@ -80,21 +96,33 @@ export function NumericInput({
   min,
   max,
   error,
+  placeholder,
+  allowNegative = false,
   onBlur,
   sizeVariant = "Full",
   fontSize = "M",
 }: NumericInputProps) {
-  const [localValue, setLocalValue] = useState(String(value));
+  // placeholder 指定時は 0 を空欄として表示し、背面テキストを見せる
+  const display = (n: number) => (placeholder != null && n === 0 ? "" : String(n));
+  const [localValue, setLocalValue] = useState(() => display(value));
 
-  const handleBlur = () => {
-    let parsed = parseFloat(localValue);
+  const commit = (raw: string) => {
+    let parsed = parseFloat(raw);
     if (isNaN(parsed)) {
-      parsed = value;
+      parsed = placeholder != null ? 0 : value;
     }
     if (min != null && parsed < min) parsed = min;
     if (max != null && parsed > max) parsed = max;
-    setLocalValue(String(parsed));
+    setLocalValue(display(parsed));
     onBlur?.(parsed);
+  };
+
+  const handleBlur = () => commit(localValue);
+
+  const toggleSign = () => {
+    const parsed = parseFloat(localValue);
+    if (isNaN(parsed) || parsed === 0) return;
+    commit(String(-parsed));
   };
 
   const wrapperStyle: CSSProperties = {
@@ -105,9 +133,20 @@ export function NumericInput({
   return (
     <div style={wrapperStyle}>
       <div style={styles.inputRow}>
+        {allowNegative && (
+          <button
+            type="button"
+            aria-label="符号を反転"
+            onClick={toggleSign}
+            style={{ ...styles.signButton, height: sizeHeightMap[sizeVariant] }}
+          >
+            ±
+          </button>
+        )}
         <input
           type="text"
-          inputMode="decimal"
+          inputMode={allowNegative ? "text" : "decimal"}
+          placeholder={placeholder}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
           onBlur={handleBlur}


### PR DESCRIPTION
- 取引リストの摘要列に maxWidth(calc(100% - 140px)) を設定し編集ボタンを確実に確保
- NumericInput に placeholder を追加し value=0 を空欄＋背面テキスト表示
- NumericInput に allowNegative と符号反転(±)ボタンを追加しマイナス入力に対応
- 取引登録のバリデーションを 0 のみ不可に変更（マイナス額を許容）

## 関連Issue

closes #

## 変更概要

<!-- 何をどう変えたか。Issue のDone条件に対応する形で書く -->

## 確認項目

- [ ] Done条件をすべて満たしている
- [ ] 型エラー・lintエラーがない
- [ ] 影響範囲の動作確認済み
