### PR TITLE
improve(モバイル): 金額入力を数字キーボード(テンキー)にする #98

### DIFF
--- a/mobile/components/NumericInput.tsx
+++ b/mobile/components/NumericInput.tsx
@@ -145,7 +145,8 @@ export function NumericInput({
         )}
         <input
           type="text"
-          inputMode={allowNegative ? "text" : "decimal"}
+          // 金額入力は数字のみ。マイナスは ± ボタンで入力するためテンキーで十分
+          inputMode="numeric"
           placeholder={placeholder}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}


### PR DESCRIPTION
## 概要
モバイル版の取引登録（取引入力カード）の金額入力欄で、フォーカス時にフルキーボードが表示されていた問題を修正。数字のみのキーボード（テンキー）を表示するようにした。

## 変更内容
- `mobile/components/NumericInput.tsx` の `inputMode` を `allowNegative ? "text" : "decimal"` から `"numeric"` に統一。
  - マイナス値は従来どおり ± ボタンで入力する。

## Done条件
- [x] モバイルの金額入力欄でフォーカスすると数字キーボード（テンキー）が表示される
- [x] マイナス値は引き続き ± ボタンで入力できる
- [x] 既存の NumericInput 利用箇所が壊れない（`tsc -b` パス）

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)