### PR TITLE
feat(モバイル): ダッシュボード期間指定に期間単位・休日ずらしを追加 #99

### DIFF
--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -15,6 +15,7 @@ import { BalanceSheetCard } from "./BalanceSheetCard";
 import { PanelButton } from "@mobile-components/PanelButton";
 import { CommonButton } from "@mobile-components/CommonButton";
 import { Dialog } from "@mobile-components/Dialog";
+import { computePeriodRange, DEFAULT_PERIOD_SETTINGS } from "@mobile-components/periodSelector.utils";
 import LoginScreen from "./LoginScreen";
 
 type TabId = "transaction" | "pl-bs" | "recurring" | "accounts";
@@ -29,16 +30,16 @@ const tabs: { id: TabId; label: string }[] = [
 
 function getDefaultDates() {
   const now = new Date();
-  const y = now.getFullYear();
-  const mo = now.getMonth();
   const fmt = (d: Date) => {
     const m = String(d.getMonth() + 1).padStart(2, "0");
     const day = String(d.getDate()).padStart(2, "0");
     return `${d.getFullYear()}-${m}-${day}`;
   };
+  // PL の期間初期値は「月単位・開始日 25 日」（例: 2026/06/25〜2026/07/24）
+  const plRange = computePeriodRange("month", DEFAULT_PERIOD_SETTINGS, now)!;
   return {
-    plStart: fmt(new Date(y, mo, 1)),
-    plEnd: fmt(new Date(y, mo + 1, 0)),
+    plStart: plRange.startDate,
+    plEnd: plRange.endDate,
     bsAsOf: fmt(now),
   };
 }

--- a/mobile/app/src/ProfitLossStatementCard.tsx
+++ b/mobile/app/src/ProfitLossStatementCard.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from "react";
 import type { ProfitLossView } from "@asset-simulator/shared";
 import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
-import { DateInput } from "@mobile-components/DateInput";
-import { CommonButton } from "@mobile-components/CommonButton";
+import { PeriodSelector } from "@mobile-components/PeriodSelector";
 import { DataGrid } from "@mobile-components/DataGrid";
 
 type Props = {
@@ -12,28 +11,8 @@ type Props = {
   onApply: (startDate: string, endDate: string) => void;
 };
 
-function fmt(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
 // 区分の表示順（損益計算書: 収益→費用）
 const CATEGORY_ORDER: Record<string, number> = { Revenue: 0, Expense: 1 };
-
-function getPeriodPresets() {
-  const now = new Date();
-  const y = now.getFullYear();
-  const mo = now.getMonth();
-  const q = Math.floor(mo / 3);
-  return {
-    thisMonth: [fmt(new Date(y, mo, 1)), fmt(new Date(y, mo + 1, 0))] as [string, string],
-    lastMonth: [fmt(new Date(y, mo - 1, 1)), fmt(new Date(y, mo, 0))] as [string, string],
-    thisQuarter: [fmt(new Date(y, q * 3, 1)), fmt(new Date(y, q * 3 + 3, 0))] as [string, string],
-    thisYear: [`${y}-01-01`, `${y}-12-31`] as [string, string],
-  };
-}
 
 export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows, onApply }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -61,12 +40,6 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
 
   const profit = revenueTotal - expenseTotal;
 
-  const presets = getPeriodPresets();
-
-  const applyPreset = (start: string, end: string) => {
-    onApply(start, end);
-  };
-
   return (
     <Card
       title="損益計算書【PL】"
@@ -75,19 +48,10 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
       onToggle={() => setIsExpanded((prev) => !prev)}
     >
       <CardBodyHead>
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            <CommonButton label="今月" fontSize="S" sizeVariant="S" colorVariant="secondary" onClick={() => applyPreset(...presets.thisMonth)} />
-            <CommonButton label="先月" fontSize="S" sizeVariant="S" colorVariant="secondary" onClick={() => applyPreset(...presets.lastMonth)} />
-            <CommonButton label="3ヶ月" fontSize="S" sizeVariant="S" colorVariant="secondary" onClick={() => applyPreset(...presets.thisQuarter)} />
-            <CommonButton label="今年" fontSize="S" sizeVariant="S" colorVariant="secondary" onClick={() => applyPreset(...presets.thisYear)} />
-          </div>
-          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-            <DateInput value={appliedStartDate} onChange={(v: string) => onApply(v, appliedEndDate)} sizeVariant="S" />
-            <span style={{ alignSelf: "center", color: "#6B7280" }}>〜</span>
-            <DateInput value={appliedEndDate} onChange={(v: string) => onApply(appliedStartDate, v)} sizeVariant="S" />
-          </div>
-        </div>
+        <PeriodSelector
+          range={{ startDate: appliedStartDate, endDate: appliedEndDate }}
+          onChange={(r) => onApply(r.startDate, r.endDate)}
+        />
       </CardBodyHead>
       <CardBodyMain>
         <DataGrid

--- a/mobile/components/DateInput.tsx
+++ b/mobile/components/DateInput.tsx
@@ -27,6 +27,7 @@ interface DateInputProps {
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
+  readOnly?: boolean;
   sizeVariant?: SizeVariant;
   fontSize?: FontSizeVariant;
 }
@@ -46,12 +47,13 @@ const styles = {
   } satisfies CSSProperties,
 };
 
-export function DateInput({ value, onChange, onBlur, sizeVariant = "Full", fontSize = "M" }: DateInputProps) {
+export function DateInput({ value, onChange, onBlur, readOnly = false, sizeVariant = "Full", fontSize = "M" }: DateInputProps) {
   const inputStyle: CSSProperties = {
     ...styles.input,
     width: sizeWidthMap[sizeVariant],
     height: sizeHeightMap[sizeVariant],
     fontSize: fontSizeMap[fontSize],
+    ...(readOnly ? { backgroundColor: "#F3F4F6", color: "#6B7280" } : {}),
   };
 
   return (
@@ -60,6 +62,7 @@ export function DateInput({ value, onChange, onBlur, sizeVariant = "Full", fontS
       value={value}
       min={DATE_MIN}
       max={DATE_MAX}
+      readOnly={readOnly}
       onChange={(e) => onChange(e.target.value)}
       onBlur={onBlur}
       style={inputStyle}

--- a/mobile/components/PeriodSelector.tsx
+++ b/mobile/components/PeriodSelector.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { SelectInput } from "./SelectInput";
+import { NumericInput } from "./NumericInput";
+import { DateInput } from "./DateInput";
+import {
+  computePeriodRange,
+  shiftPeriodRange,
+  DEFAULT_PERIOD_SETTINGS,
+  type PeriodPreset,
+  type PeriodRange,
+  type PeriodSettings,
+  type HolidayAdjustment,
+} from "./periodSelector.utils";
+
+interface PeriodSelectorProps {
+  range: PeriodRange;
+  onChange: (range: PeriodRange) => void;
+  defaultPreset?: PeriodPreset;
+  defaultSettings?: Partial<PeriodSettings>;
+}
+
+const presetOptions = [
+  { label: "週単位", value: "week" },
+  { label: "月単位", value: "month" },
+  { label: "年単位", value: "year" },
+  { label: "カスタム", value: "custom" },
+];
+
+const dayOfWeekOptions = ["日", "月", "火", "水", "木", "金", "土"].map((d, i) => ({
+  label: `${d}曜日`,
+  value: i,
+}));
+
+const holidayOptions = [
+  { label: "ずらしなし", value: "none" },
+  { label: "前倒し", value: "before" },
+  { label: "後倒し", value: "after" },
+];
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  } satisfies CSSProperties,
+  row: {
+    display: "flex",
+    gap: 8,
+    flexWrap: "wrap",
+    alignItems: "center",
+  } satisfies CSSProperties,
+  navButton: {
+    flexShrink: 0,
+    width: 36,
+    height: 32,
+    borderRadius: 8,
+    border: "1px solid #D1D5DB",
+    backgroundColor: "#F9FAFB",
+    color: "#374151",
+    fontSize: 16,
+    fontWeight: 700,
+    cursor: "pointer",
+  } satisfies CSSProperties,
+  separator: {
+    alignSelf: "center",
+    color: "#6B7280",
+  } satisfies CSSProperties,
+};
+
+export function PeriodSelector({
+  range,
+  onChange,
+  defaultPreset = "month",
+  defaultSettings,
+}: PeriodSelectorProps) {
+  const [preset, setPreset] = useState<PeriodPreset>(defaultPreset);
+  const [settings, setSettings] = useState<PeriodSettings>(() => ({
+    ...DEFAULT_PERIOD_SETTINGS,
+    ...defaultSettings,
+  }));
+
+  // 親が毎レンダーで新しい onChange を渡しても効果が再実行されないよう ref 経由で参照する。
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  // プリセット/設定が変わったとき（custom 以外）に範囲を再計算して通知する。
+  // range を依存に含めないことで、矢印操作や親の更新による再計算ループを防ぐ。
+  useEffect(() => {
+    if (preset === "custom") return;
+    const next = computePeriodRange(preset, settings);
+    if (next) onChangeRef.current(next);
+  }, [preset, settings]);
+
+  const updateSetting = <K extends keyof PeriodSettings>(key: K, value: PeriodSettings[K]) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleShift = (direction: "prev" | "next") => {
+    const next = shiftPeriodRange(preset, settings, range, direction);
+    if (next) onChange(next);
+  };
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.row}>
+        {preset !== "custom" && (
+          <>
+            <button type="button" aria-label="前の期間へ" style={styles.navButton} onClick={() => handleShift("prev")}>
+              ←
+            </button>
+            <button type="button" aria-label="次の期間へ" style={styles.navButton} onClick={() => handleShift("next")}>
+              →
+            </button>
+          </>
+        )}
+        <SelectInput
+          options={presetOptions}
+          value={preset}
+          onChange={(v) => setPreset(v as PeriodPreset)}
+          sizeVariant="S"
+          fontSize="S"
+        />
+
+        {preset === "week" && (
+          <SelectInput
+            options={dayOfWeekOptions}
+            value={settings.startDayOfWeek}
+            onChange={(v) => updateSetting("startDayOfWeek", Number(v))}
+            sizeVariant="S"
+            fontSize="S"
+          />
+        )}
+
+        {preset === "month" && (
+          <>
+            <NumericInput
+              value={settings.startDayOfMonth}
+              unit="日開始"
+              min={1}
+              max={31}
+              onBlur={(v) => updateSetting("startDayOfMonth", v)}
+              sizeVariant="S"
+              fontSize="S"
+            />
+            <SelectInput
+              options={holidayOptions}
+              value={settings.holidayAdjustment}
+              onChange={(v) => updateSetting("holidayAdjustment", v as HolidayAdjustment)}
+              sizeVariant="S"
+              fontSize="S"
+            />
+          </>
+        )}
+
+        {preset === "year" && (
+          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <NumericInput
+              value={settings.startMonth}
+              unit="月"
+              min={1}
+              max={12}
+              onBlur={(v) => updateSetting("startMonth", v)}
+              sizeVariant="S"
+              fontSize="S"
+            />
+            <NumericInput
+              value={settings.startMonthDay}
+              unit="日"
+              min={1}
+              max={31}
+              onBlur={(v) => updateSetting("startMonthDay", v)}
+              sizeVariant="S"
+              fontSize="S"
+            />
+          </div>
+        )}
+      </div>
+
+      <div style={styles.row}>
+        <DateInput
+          value={range.startDate}
+          readOnly={preset !== "custom"}
+          onChange={(v) => onChange({ ...range, startDate: v })}
+          sizeVariant="S"
+        />
+        <span style={styles.separator}>〜</span>
+        <DateInput
+          value={range.endDate}
+          readOnly={preset !== "custom"}
+          onChange={(v) => onChange({ ...range, endDate: v })}
+          sizeVariant="S"
+        />
+      </div>
+    </div>
+  );
+}

--- a/mobile/components/periodSelector.utils.ts
+++ b/mobile/components/periodSelector.utils.ts
@@ -1,0 +1,132 @@
+export type PeriodPreset = "week" | "month" | "year" | "custom";
+export type HolidayAdjustment = "none" | "before" | "after";
+
+export interface PeriodRange {
+  startDate: string;
+  endDate: string;
+}
+
+export interface PeriodSettings {
+  /** 週単位の開始曜日（0:日 〜 6:土） */
+  startDayOfWeek: number;
+  /** 月単位の開始日（1〜31） */
+  startDayOfMonth: number;
+  /** 月単位の休日（土日）ずらし */
+  holidayAdjustment: HolidayAdjustment;
+  /** 年単位の開始月（1〜12） */
+  startMonth: number;
+  /** 年単位の開始日（1〜31） */
+  startMonthDay: number;
+}
+
+export const DEFAULT_PERIOD_SETTINGS: PeriodSettings = {
+  startDayOfWeek: 1, // 月曜
+  startDayOfMonth: 25,
+  holidayAdjustment: "none",
+  startMonth: 1,
+  startMonthDay: 1,
+};
+
+// タイムゾーンのズレを防ぐフォーマット (YYYY-MM-DD)
+export function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// 休日（土日）調整: before=前倒し / after=後倒し / none=何もしない
+function adjustHoliday(date: Date, adj: HolidayAdjustment): Date {
+  const result = new Date(date);
+  if (adj === "none") return result;
+  const day = result.getDay();
+  if (day === 0) {
+    // 日曜
+    result.setDate(result.getDate() + (adj === "after" ? 1 : -2));
+  } else if (day === 6) {
+    // 土曜
+    result.setDate(result.getDate() + (adj === "after" ? 2 : -1));
+  }
+  return result;
+}
+
+/**
+ * プリセットと設定から期間（開始日・終了日）を計算する。
+ * custom の場合は null を返す（呼び出し側で既存の値を維持する）。
+ */
+export function computePeriodRange(
+  preset: PeriodPreset,
+  settings: PeriodSettings,
+  base: Date = new Date()
+): PeriodRange | null {
+  const today = new Date(base.getFullYear(), base.getMonth(), base.getDate());
+  let start: Date;
+  let end: Date;
+
+  switch (preset) {
+    case "week": {
+      const currentDay = today.getDay();
+      const diff = (currentDay < settings.startDayOfWeek ? 7 : 0) + currentDay - settings.startDayOfWeek;
+      start = new Date(today.getFullYear(), today.getMonth(), today.getDate() - diff);
+      end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6);
+      break;
+    }
+    case "month": {
+      start = new Date(today.getFullYear(), today.getMonth(), settings.startDayOfMonth);
+      if (start > today) start.setMonth(start.getMonth() - 1);
+      end = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1);
+      start = adjustHoliday(start, settings.holidayAdjustment);
+      end = adjustHoliday(end, settings.holidayAdjustment);
+      break;
+    }
+    case "year": {
+      start = new Date(today.getFullYear(), settings.startMonth - 1, settings.startMonthDay);
+      if (start > today) start.setFullYear(start.getFullYear() - 1);
+      end = new Date(start.getFullYear() + 1, start.getMonth(), start.getDate() - 1);
+      break;
+    }
+    default:
+      return null;
+  }
+
+  return { startDate: formatDate(start), endDate: formatDate(end) };
+}
+
+/** 前/次の期間へ移動した範囲を計算する。custom は null。 */
+export function shiftPeriodRange(
+  preset: PeriodPreset,
+  settings: PeriodSettings,
+  current: PeriodRange,
+  direction: "prev" | "next"
+): PeriodRange | null {
+  const offset = direction === "next" ? 1 : -1;
+  const currentStart = new Date(current.startDate);
+  let start: Date;
+  let end: Date;
+
+  switch (preset) {
+    case "week": {
+      start = new Date(currentStart);
+      start.setDate(currentStart.getDate() + offset * 7);
+      end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6);
+      break;
+    }
+    case "month": {
+      start = new Date(currentStart.getFullYear(), currentStart.getMonth() + offset, settings.startDayOfMonth);
+      end = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1);
+      start = adjustHoliday(start, settings.holidayAdjustment);
+      end = adjustHoliday(end, settings.holidayAdjustment);
+      break;
+    }
+    case "year": {
+      start = new Date(currentStart);
+      start.setFullYear(currentStart.getFullYear() + offset);
+      end = new Date(start.getFullYear() + 1, start.getMonth(), start.getDate() - 1);
+      break;
+    }
+    default:
+      return null;
+  }
+
+  return { startDate: formatDate(start), endDate: formatDate(end) };
+}


### PR DESCRIPTION
## 概要
モバイルのダッシュボード（損益計算書 PL）の期間指定を強化した。期間の初期値設定・期間単位の選択・月単位の休日ずらしに対応する `PeriodSelector` コンポーネントを追加し、PL カードのヘッダに組み込んだ。

## 変更内容
- `mobile/components/PeriodSelector.tsx` を追加
  - 期間単位を **週単位 / 月単位 / 年単位 / カスタム** から選択
  - **月単位**: 開始日（1〜31）と、休日(土日)ずらし **前倒し / 後倒し / ずらしなし** を指定
  - **週単位**: 開始曜日を指定 / **年単位**: 開始月日を指定
  - **← →** で前/次の期間へ移動
  - カスタム時のみ日付を手動編集可能
- `mobile/components/periodSelector.utils.ts` を追加（期間計算ロジックを分離）
- `mobile/app/src/ProfitLossStatementCard.tsx`: 旧プリセットボタン/日付入力を `PeriodSelector` に置き換え
- `mobile/app/src/App.tsx`: PL 期間の初期値を「月単位・開始日25日」に統一（例: **2026/06/25〜2026/07/24**）
- `mobile/components/DateInput.tsx`: `readOnly` プロパティを追加

## Done条件
- [x] 期間の初期値を設定できる（例: 2026/06/25〜2026/07/24）
- [x] 期間単位を 週単位・月単位・年単位・カスタム から選べる
- [x] 月単位の場合、休日ずらしを 前倒し・後倒し・何もしない から選べる
- [x] 前/次の期間へ移動できる
- [x] 指定に応じて PL の集計が再取得される（`onApply` → 親の再フェッチ）

## 確認
- `tsc -b` / `eslint` / `vite build` すべてパス
- 期間計算を検証: 月25日始まり→ `2026-06-25〜2026-07-24`、月曜始まり週→ `2026-06-29〜2026-07-05`、年(1/1)→ `2026-01-01〜2026-12-31`

closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)