### PR TITLE
【モバイル / 機能修正】定期取引の登録画面をダイアログ表示に変更

### DIFF
--- a/mobile/app/src/RecurringTransactionCard.tsx
+++ b/mobile/app/src/RecurringTransactionCard.tsx
@@ -7,6 +7,7 @@ import { DateInput } from "@mobile-components/DateInput";
 import { NumericInput } from "@mobile-components/NumericInput";
 import { SelectInput } from "@mobile-components/SelectInput";
 import { CommonButton } from "@mobile-components/CommonButton";
+import { Dialog } from "@mobile-components/Dialog";
 
 const PLACEHOLDER = { label: "選択してください", value: "" };
 
@@ -32,6 +33,7 @@ export function RecurringTransactionCard() {
   const executeDueRegularJournalEntries = useFinancialStore((s) => s.executeDueRegularJournalEntries);
 
   const [isExpanded, setIsExpanded] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [name, setName] = useState("");
   const [startDate, setStartDate] = useState(() => new Date().toLocaleDateString("sv-SE"));
   const [frequency, setFrequency] = useState<RecurrenceFrequency>("monthly");
@@ -41,6 +43,26 @@ export function RecurringTransactionCard() {
   const [creditAccountId, setCreditAccountId] = useState("");
   const [amount, setAmount] = useState(0);
   const [busy, setBusy] = useState(false);
+
+  const resetForm = () => {
+    setName("");
+    setStartDate(new Date().toLocaleDateString("sv-SE"));
+    setFrequency("monthly");
+    setDateOfMonth(1);
+    setDateOfYear("01-01");
+    setDebitAccountId("");
+    setCreditAccountId("");
+    setAmount(0);
+  };
+
+  const openDialog = () => {
+    resetForm();
+    setIsDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+  };
 
   const accountOptions = useMemo(
     () => [PLACEHOLDER, ...journalAccounts.map((acc) => ({ label: acc.name, value: acc.id }))],
@@ -96,8 +118,7 @@ export function RecurringTransactionCard() {
         user_id: "",
       };
       await addRegularJournalEntry(entry);
-      setName("");
-      setAmount(0);
+      closeDialog();
     } catch (error) {
       console.error("Failed to add regular journal entry:", error);
       alert("定期取引の保存に失敗しました。通信を確認してください。");
@@ -120,13 +141,55 @@ export function RecurringTransactionCard() {
   };
 
   return (
-    <Card
-      title="定期取引管理"
-      subInfo={`${regularJournalEntries.length} 件登録されています`}
-      isExpanded={isExpanded}
-      onToggle={() => setIsExpanded((prev) => !prev)}
-    >
-      <CardBodyHead>
+    <>
+      <Card
+        title="定期取引管理"
+        subInfo={`${regularJournalEntries.length} 件登録されています`}
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded((prev) => !prev)}
+      >
+        <CardBodyHead>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <CommonButton label="追加" onClick={openDialog} />
+            <CommonButton label="期限到来分を実行" colorVariant="secondary" onClick={runDue} />
+          </div>
+        </CardBodyHead>
+        <CardBodyMain>
+          <div style={{ display: "grid", gap: 8 }}>
+            {regularJournalEntries.length === 0 && (
+              <div style={{ color: "#6B7280", fontSize: 14 }}>登録された定期取引はありません。</div>
+            )}
+            {regularJournalEntries.map((item) => (
+              <div
+                key={item.id}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "10px 12px",
+                  border: "1px solid #E5E7EB",
+                  borderRadius: 8,
+                  flexWrap: "wrap",
+                }}
+              >
+                <div style={{ display: "grid", gap: 2 }}>
+                  <div style={{ fontWeight: 700, fontSize: 14 }}>{item.name}</div>
+                  <div style={{ fontSize: 12, color: "#6B7280" }}>
+                    {frequencyLabel[item.frequency] ?? item.frequency} ・ {accountName[item.debitAccountId] ?? item.debitAccountId} / {accountName[item.creditAccountId] ?? item.creditAccountId} ・ ¥{item.amount.toLocaleString()}
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 8 }}>
+                  <CommonButton label="実行" sizeVariant="S" fontSize="S" onClick={() => executeRegularJournalEntry(item)} />
+                  <CommonButton label="削除" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => deleteRegularJournalEntry(item)} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardBodyMain>
+      </Card>
+
+      <Dialog isOpen={isDialogOpen} onClose={closeDialog} title="定期取引の登録">
         <div style={{ display: "grid", gap: 16 }}>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "flex-end" }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
@@ -166,45 +229,12 @@ export function RecurringTransactionCard() {
             </div>
             <NumericInput value={amount} unit="円" onBlur={setAmount} sizeVariant="M" />
           </div>
-          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-            <CommonButton label={busy ? "処理中..." : "定期取引を保存"} onClick={addRecurring} />
-            <CommonButton label="期限到来分を実行" colorVariant="secondary" onClick={runDue} />
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <CommonButton label="キャンセル" colorVariant="secondary" onClick={closeDialog} />
+            <CommonButton label={busy ? "登録中..." : "登録"} onClick={addRecurring} />
           </div>
         </div>
-      </CardBodyHead>
-      <CardBodyMain>
-        <div style={{ display: "grid", gap: 8 }}>
-          {regularJournalEntries.length === 0 && (
-            <div style={{ color: "#6B7280", fontSize: 14 }}>登録された定期取引はありません。</div>
-          )}
-          {regularJournalEntries.map((item) => (
-            <div
-              key={item.id}
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                gap: 12,
-                padding: "10px 12px",
-                border: "1px solid #E5E7EB",
-                borderRadius: 8,
-                flexWrap: "wrap",
-              }}
-            >
-              <div style={{ display: "grid", gap: 2 }}>
-                <div style={{ fontWeight: 700, fontSize: 14 }}>{item.name}</div>
-                <div style={{ fontSize: 12, color: "#6B7280" }}>
-                  {frequencyLabel[item.frequency] ?? item.frequency} ・ {accountName[item.debitAccountId] ?? item.debitAccountId} / {accountName[item.creditAccountId] ?? item.creditAccountId} ・ ¥{item.amount.toLocaleString()}
-                </div>
-              </div>
-              <div style={{ display: "flex", gap: 8 }}>
-                <CommonButton label="実行" sizeVariant="S" fontSize="S" onClick={() => executeRegularJournalEntry(item)} />
-                <CommonButton label="削除" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => deleteRegularJournalEntry(item)} />
-              </div>
-            </div>
-          ))}
-        </div>
-      </CardBodyMain>
-    </Card>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
closes #79

## 概要
定期取引の登録フォームを常時展開ではなく、ダイアログ表示に変更しました。

## 変更内容
- 定期取引管理カードのヘッダーに「追加」ボタンを追加
- 「追加」ボタン押下で登録ダイアログを表示（フォームは初期化）
- ダイアログ内で定期取引情報を入力し「登録」ボタンで保存 → 成功時にダイアログを閉じる
- 「キャンセル」ボタン／×／オーバーレイクリックでダイアログを閉じる
- 「期限到来分を実行」ボタンはカードヘッダーに残置

## Done条件
- [x] 追加ボタン押下 → 登録ダイアログ画面表示
- [x] 定期取引情報を入力し「登録」ボタンを押下 → 保存

## 動作確認
- `vite build` 成功
- `eslint` 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)