### PR TITLE
【モバイル / 機能修正】ダッシュボードの画面構成の改修

### DIFF
--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -15,11 +15,11 @@ import { BalanceSheetCard } from "./BalanceSheetCard";
 import { PanelButton } from "@mobile-components/PanelButton";
 import { CommonButton } from "@mobile-components/CommonButton";
 import { Dialog } from "@mobile-components/Dialog";
+import { PeriodSelector } from "@mobile-components/PeriodSelector";
 import { computePeriodRange, DEFAULT_PERIOD_SETTINGS } from "@mobile-components/periodSelector.utils";
 import LoginScreen from "./LoginScreen";
 
 type TabId = "transaction" | "pl-bs" | "recurring" | "accounts";
-type PlViewType = "profit-loss" | "balance-sheet" | "none";
 
 const tabs: { id: TabId; label: string }[] = [
   { id: "transaction", label: "取引" },
@@ -99,8 +99,9 @@ function App() {
   const [plRows, setPlRows] = useState<ProfitLossView[]>([]);
   const [bsRows, setBsRows] = useState<BalanceSheetView[]>([]);
 
-  const plCardRef = useRef<HTMLDivElement>(null);
-  const bsCardRef = useRef<HTMLDivElement>(null);
+  // 各パネルのサマリーリストの表示/非表示
+  const [isProfitOpen, setIsProfitOpen] = useState(false);
+  const [isNetAssetsOpen, setIsNetAssetsOpen] = useState(false);
 
   // PL/BS ビューはサーバー集計を取得（日付変更・取引登録時に再取得）
   useEffect(() => {
@@ -137,12 +138,12 @@ function App() {
     return assets - liabilities;
   }, [bsRows]);
 
-  const setPlView = (view: PlViewType) => {
-    if (view === "profit-loss") {
-      plCardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    } else if (view === "balance-sheet") {
-      bsCardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
+  // ダッシュボード最上部の期間指定。
+  // PL は指定期間、BS の基準日は期間の終了日に同期し、各パネルの金額表示を更新する。
+  const handleDashboardPeriodChange = (startDate: string, endDate: string) => {
+    setPlStartDate(startDate);
+    setPlEndDate(endDate);
+    setBsAsOfDate(endDate);
   };
 
   const handleDateSelect = (date: string) => {
@@ -180,22 +181,35 @@ function App() {
         );
       case "pl-bs":
         return (
-          <div style={{ display: "grid", gap: 24 }}>
+          <div style={{ display: "grid", gap: 16 }}>
+            {/* ダッシュボード最上部の期間指定（PL 期間・BS 基準日を一括同期） */}
+            <div
+              style={{
+                width: "100%",
+                maxWidth: 358,
+                borderRadius: 12,
+                background: "#FFFFFF",
+                boxShadow: "0px 4px 12px rgba(0,0,0,0.08)",
+                boxSizing: "border-box",
+                padding: 20,
+              }}
+            >
+              <PeriodSelector
+                range={{ startDate: plStartDate, endDate: plEndDate }}
+                onChange={(r) => handleDashboardPeriodChange(r.startDate, r.endDate)}
+              />
+            </div>
+
+            {/* 純利益パネル: パネルボタン → 収益・費用サマリーリスト */}
             <div style={{ display: "grid", gap: 16 }}>
               <PanelButton
                 title="当期純利益"
                 value={`¥${profit.toLocaleString()}`}
                 subText={`${plStartDate} 〜 ${plEndDate}`}
-                onClick={() => setPlView("profit-loss")}
+                onClick={() => setIsProfitOpen((prev) => !prev)}
               />
-              <PanelButton
-                title="純資産合計"
-                value={`¥${netAssets.toLocaleString()}`}
-                subText={`基準日: ${bsAsOfDate}`}
-                onClick={() => setPlView("balance-sheet")}
-              />
-
-              <div ref={plCardRef}>
+              {/* サマリーリストは常時マウントし表示のみ切り替える（期間セレクターのマウント時リセットを防ぐ） */}
+              <div style={{ display: isProfitOpen ? "block" : "none" }}>
                 <ProfitLossStatementCard
                   appliedStartDate={plStartDate}
                   appliedEndDate={plEndDate}
@@ -203,13 +217,23 @@ function App() {
                   onApply={(s, e) => { setPlStartDate(s); setPlEndDate(e); }}
                 />
               </div>
-              <div ref={bsCardRef}>
+            </div>
+
+            {/* 純資産パネル: パネルボタン → 資産・負債サマリーリスト */}
+            <div style={{ display: "grid", gap: 16 }}>
+              <PanelButton
+                title="純資産合計"
+                value={`¥${netAssets.toLocaleString()}`}
+                subText={`基準日: ${bsAsOfDate}`}
+                onClick={() => setIsNetAssetsOpen((prev) => !prev)}
+              />
+              {isNetAssetsOpen && (
                 <BalanceSheetCard
                   appliedAsOfDate={bsAsOfDate}
                   rows={bsRows}
                   onApply={(d) => setBsAsOfDate(d)}
                 />
-              </div>
+              )}
             </div>
           </div>
         );

--- a/mobile/app/src/BalanceSheetCard.tsx
+++ b/mobile/app/src/BalanceSheetCard.tsx
@@ -1,6 +1,5 @@
-import { useMemo, useState } from "react";
+import { useMemo, type CSSProperties } from "react";
 import type { BalanceSheetView } from "@asset-simulator/shared";
-import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
 import { DateInput } from "@mobile-components/DateInput";
 import { CommonButton } from "@mobile-components/CommonButton";
 import { DataGrid } from "@mobile-components/DataGrid";
@@ -21,6 +20,19 @@ function fmt(d: Date): string {
 // 区分の表示順（貸借対照表: 資産→負債→純資産）
 const CATEGORY_ORDER: Record<string, number> = { Asset: 0, Liability: 1, Equity: 2 };
 
+const container: CSSProperties = {
+  width: "100%",
+  maxWidth: 358,
+  borderRadius: 12,
+  background: "#FFFFFF",
+  boxShadow: "0px 4px 12px rgba(0,0,0,0.08)",
+  boxSizing: "border-box",
+  padding: 20,
+  display: "flex",
+  flexDirection: "column",
+  gap: 16,
+};
+
 function getDatePresets() {
   const now = new Date();
   const y = now.getFullYear();
@@ -32,9 +44,8 @@ function getDatePresets() {
   };
 }
 
+// 資産・負債サマリーリスト（純資産パネル配下に表示される明細）
 export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   // サーバー集計済みの BalanceSheetView を表示用の行へマッピング（区分→勘定科目でソート）
   const grouped = useMemo(
     () =>
@@ -63,25 +74,18 @@ export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
   };
 
   return (
-    <Card
-      title="貸借対照表【BS】"
-      subInfo={appliedAsOfDate}
-      isExpanded={isExpanded}
-      onToggle={() => setIsExpanded((prev) => !prev)}
-    >
-      <CardBodyHead>
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            <CommonButton label="今日" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.today)} />
-            <CommonButton label="今月末" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.thisMonthEnd)} />
-            <CommonButton label="先月末" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.lastMonthEnd)} />
-          </div>
-          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-            <DateInput value={appliedAsOfDate} onChange={(v: string) => onApply(v)} sizeVariant="M" />
-          </div>
+    <div style={container}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          <CommonButton label="今日" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.today)} />
+          <CommonButton label="今月末" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.thisMonthEnd)} />
+          <CommonButton label="先月末" sizeVariant="S" fontSize="S" colorVariant="secondary" onClick={() => applyPreset(presets.lastMonthEnd)} />
         </div>
-      </CardBodyHead>
-      <CardBodyMain>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+          <DateInput value={appliedAsOfDate} onChange={(v: string) => onApply(v)} sizeVariant="M" />
+        </div>
+      </div>
+      <div>
         <DataGrid
           data={grouped}
           columns={[
@@ -121,7 +125,7 @@ export function BalanceSheetCard({ appliedAsOfDate, rows, onApply }: Props) {
             <span>¥{summeryTotal.toLocaleString()}</span>
           </div>
         </div>
-      </CardBodyMain>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/mobile/app/src/ProfitLossStatementCard.tsx
+++ b/mobile/app/src/ProfitLossStatementCard.tsx
@@ -1,6 +1,5 @@
-import { useMemo, useState } from "react";
+import { useMemo, type CSSProperties } from "react";
 import type { ProfitLossView } from "@asset-simulator/shared";
-import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
 import { PeriodSelector } from "@mobile-components/PeriodSelector";
 import { DataGrid } from "@mobile-components/DataGrid";
 
@@ -14,9 +13,21 @@ type Props = {
 // 区分の表示順（損益計算書: 収益→費用）
 const CATEGORY_ORDER: Record<string, number> = { Revenue: 0, Expense: 1 };
 
-export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows, onApply }: Props) {
-  const [isExpanded, setIsExpanded] = useState(false);
+const container: CSSProperties = {
+  width: "100%",
+  maxWidth: 358,
+  borderRadius: 12,
+  background: "#FFFFFF",
+  boxShadow: "0px 4px 12px rgba(0,0,0,0.08)",
+  boxSizing: "border-box",
+  padding: 20,
+  display: "flex",
+  flexDirection: "column",
+  gap: 16,
+};
 
+// 収益・費用サマリーリスト（純利益パネル配下に表示される明細）
+export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows, onApply }: Props) {
   // サーバー集計済みの ProfitLossView を表示用の行へマッピング（区分→勘定科目でソート）
   const grouped = useMemo(
     () =>
@@ -41,19 +52,12 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
   const profit = revenueTotal - expenseTotal;
 
   return (
-    <Card
-      title="損益計算書【PL】"
-      subInfo={`${appliedStartDate} 〜 ${appliedEndDate}`}
-      isExpanded={isExpanded}
-      onToggle={() => setIsExpanded((prev) => !prev)}
-    >
-      <CardBodyHead>
-        <PeriodSelector
-          range={{ startDate: appliedStartDate, endDate: appliedEndDate }}
-          onChange={(r) => onApply(r.startDate, r.endDate)}
-        />
-      </CardBodyHead>
-      <CardBodyMain>
+    <div style={container}>
+      <PeriodSelector
+        range={{ startDate: appliedStartDate, endDate: appliedEndDate }}
+        onChange={(r) => onApply(r.startDate, r.endDate)}
+      />
+      <div>
         <DataGrid
           data={grouped}
           columns={[
@@ -93,7 +97,7 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
             <span>¥{profit.toLocaleString()}</span>
           </div>
         </div>
-      </CardBodyMain>
-    </Card>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
closes #78

## 概要
ダッシュボード（PL/BS タブ）を、パネルボタンとサマリーリストをまとめた開閉式の構成に改修しました。

## 変更内容
### 画面構成
- **純利益パネル**: 純利益パネルボタン → 収益・費用サマリーリスト
- **純資産パネル**: 純資産パネルボタン → 資産・負債サマリーリスト
- ダッシュボード最上部に期間指定（PeriodSelector）を追加

### 挙動
- 純利益パネルボタン押下 → 収益・費用サマリーリストの表示/非表示を切り替え
- 純利益パネル側で期間指定 → 収益・費用サマリー再取得＋純利益パネルの金額表示を更新
- 純資産パネルボタン押下 → 資産・負債サマリーリストの表示/非表示を切り替え
- 純資産パネル側で基準日指定 → 資産・負債サマリー再取得＋純資産パネルの金額表示を更新
- ダッシュボード最上部で期間指定 → BS 基準日を終了日に同期し、各パネルの金額表示を更新

### 実装メモ
- 従来スクロール移動していたパネルボタンを開閉トグルに変更
- `ProfitLossStatementCard` / `BalanceSheetCard` は Card ラッパーを外し、パネル配下のサマリーリストとしてヘッドレス化
- サマリーリストは常時マウントし `display` で表示切替（期間セレクターのマウント時リセットを防止）

## Done条件
- [x] 純利益パネル / 純資産パネルの「パネルボタン → サマリーリスト」構成
- [x] パネルボタン押下でサマリーリストの表示/非表示切り替え
- [x] 各パネル側の期間指定でサマリー再取得・金額更新
- [x] 最上部の期間指定で BS 基準日同期・各パネル金額更新

## 動作確認
- `vite build` 成功
- `eslint` 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)