### PR TITLE
【モバイル / 機能修正】定期取引の取引名称と摘要を別名で登録可能にする

### DIFF
--- a/mobile/app/src/RecurringTransactionCard.tsx
+++ b/mobile/app/src/RecurringTransactionCard.tsx
@@ -35,6 +35,7 @@ export function RecurringTransactionCard() {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [startDate, setStartDate] = useState(() => new Date().toLocaleDateString("sv-SE"));
   const [frequency, setFrequency] = useState<RecurrenceFrequency>("monthly");
   const [dateOfMonth, setDateOfMonth] = useState(1);
@@ -46,6 +47,7 @@ export function RecurringTransactionCard() {
 
   const resetForm = () => {
     setName("");
+    setDescription("");
     setStartDate(new Date().toLocaleDateString("sv-SE"));
     setFrequency("monthly");
     setDateOfMonth(1);
@@ -106,7 +108,7 @@ export function RecurringTransactionCard() {
     try {
       const entry: Omit<RecurringTransaction, "id"> = {
         name,
-        description: name,
+        description: description.trim() || name,
         debitAccountId,
         creditAccountId,
         amount,
@@ -217,6 +219,9 @@ export function RecurringTransactionCard() {
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             <DateInput value={startDate} onChange={setStartDate} sizeVariant="M" />
             <TextInput placeholder="取引名称" value={name} onChange={setName} sizeVariant="Full" />
+          </div>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <TextInput placeholder="摘要（未入力時は取引名称を使用）" value={description} onChange={setDescription} sizeVariant="Full" />
           </div>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             <div className="column" style={{ display: "flex", flexDirection: "column", gap: 4 }}>


### PR DESCRIPTION
closes #104

## 概要
定期取引の登録で、取引名称と摘要を別々に指定できるようにしました。
（#79 / PR #102 マージ後の追加要望。マージ済みブランチには追記できないため、新 Issue #104 / 新 PR として作成）

## 変更内容
- 登録ダイアログに「摘要」の入力欄を追加
- 取引名称と摘要を別名で登録できるように変更
- 摘要が未入力の場合は従来どおり取引名称を摘要として使用（後方互換）

## Done条件
- [x] 取引名称と摘要を別々に入力・登録できる
- [x] 摘要未入力時は取引名称を摘要として使用

## 動作確認
- `vite build` 成功
- `eslint` 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)