### PR TITLE
fix(全体): 月単位の休日ずらしで期間終了日が次期間開始日に重なる不具合を修正 #106

### DIFF
--- a/desktop/src/components/common/DateRangePicker.tsx
+++ b/desktop/src/components/common/DateRangePicker.tsx
@@ -64,10 +64,11 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
       case '1-month':
         start = new Date(today.getFullYear(), today.getMonth(), startDayOfMonth);
         if (start > today) start.setMonth(start.getMonth() - 1);
-        
-        end = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1);
+
+        // 終了日は「翌期間の（調整後）開始日の前日」とし、期間が重複・欠落しないようにする
+        end = adjustDate(new Date(start.getFullYear(), start.getMonth() + 1, startDayOfMonth), holidayAdj);
+        end.setDate(end.getDate() - 1);
         start = adjustDate(start, holidayAdj);
-        end = adjustDate(end, holidayAdj);
         break;
 
       case '1-year':
@@ -100,14 +101,15 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
         newEnd = new Date(newStart.getFullYear(), newStart.getMonth(), newStart.getDate() + 6);
         break;
 
-      case '1-month':
-        // 現在の月から相対的に移動し、開始日設定(startDayOfMonth)を再適用
-        newStart = new Date(currentStart.getFullYear(), currentStart.getMonth() + offset, startDayOfMonth);
-        newEnd = new Date(newStart.getFullYear(), newStart.getMonth() + 1, newStart.getDate() - 1);
-        // 移動先でも休日調整を反映
-        newStart = adjustDate(newStart, holidayAdj);
-        newEnd = adjustDate(newEnd, holidayAdj);
+      case '1-month': {
+        // currentStart は調整後の日付なので、開始日設定(startDayOfMonth)から未調整の基準日を復元して移動
+        const anchor = new Date(currentStart.getFullYear(), currentStart.getMonth() + offset, startDayOfMonth);
+        // 終了日は「翌期間の（調整後）開始日の前日」とし、期間が重複・欠落しないようにする
+        newEnd = adjustDate(new Date(anchor.getFullYear(), anchor.getMonth() + 1, startDayOfMonth), holidayAdj);
+        newEnd.setDate(newEnd.getDate() - 1);
+        newStart = adjustDate(anchor, holidayAdj);
         break;
+      }
 
       case '1-year':
         newStart.setFullYear(currentStart.getFullYear() + offset);

--- a/mobile/components/periodSelector.utils.ts
+++ b/mobile/components/periodSelector.utils.ts
@@ -74,9 +74,13 @@ export function computePeriodRange(
     case "month": {
       start = new Date(today.getFullYear(), today.getMonth(), settings.startDayOfMonth);
       if (start > today) start.setMonth(start.getMonth() - 1);
-      end = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1);
+      // 終了日は「翌期間の（調整後）開始日の前日」とし、期間が重複・欠落しないようにする
+      end = adjustHoliday(
+        new Date(start.getFullYear(), start.getMonth() + 1, settings.startDayOfMonth),
+        settings.holidayAdjustment
+      );
+      end.setDate(end.getDate() - 1);
       start = adjustHoliday(start, settings.holidayAdjustment);
-      end = adjustHoliday(end, settings.holidayAdjustment);
       break;
     }
     case "year": {
@@ -112,10 +116,15 @@ export function shiftPeriodRange(
       break;
     }
     case "month": {
-      start = new Date(currentStart.getFullYear(), currentStart.getMonth() + offset, settings.startDayOfMonth);
-      end = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1);
-      start = adjustHoliday(start, settings.holidayAdjustment);
-      end = adjustHoliday(end, settings.holidayAdjustment);
+      // currentStart は調整後の日付なので、開始日設定から未調整の基準日を復元して移動する
+      const anchor = new Date(currentStart.getFullYear(), currentStart.getMonth() + offset, settings.startDayOfMonth);
+      // 終了日は「翌期間の（調整後）開始日の前日」とし、期間が重複・欠落しないようにする
+      end = adjustHoliday(
+        new Date(anchor.getFullYear(), anchor.getMonth() + 1, settings.startDayOfMonth),
+        settings.holidayAdjustment
+      );
+      end.setDate(end.getDate() - 1);
+      start = adjustHoliday(anchor, settings.holidayAdjustment);
       break;
     }
     case "year": {


### PR DESCRIPTION
closes #106

## 概要

ダッシュボードの月単位の期間指定で、休日ずらしを「前倒し」/「後倒し」にすると、ある期間の終了日が次期間の開始日と重なる不具合を修正する。

例（25日開始・前倒し）:
- 修正前: `2026/6/25 〜 2026/7/24` / `2026/7/24 〜 2026/8/24`（`7/24` が重複）
- 修正後: `2026/6/25 〜 2026/7/23` / `2026/7/24 〜 2026/8/24`（連続）

## 原因

終了日を「翌月開始日 − 1日（24日）」として算出し、その後で開始日（25日）とは**別々に**休日ずらしを適用していた。異なる基準日から独立して調整するため、調整後に境界が重複・欠落していた。

## 修正内容

終了日を「**翌期間の（調整後）開始日の前日**」として算出し、境界を単一の調整済み開始日に統一。

- `mobile/components/periodSelector.utils.ts` — `computePeriodRange` / `shiftPeriodRange` の month ケース
- `desktop/src/components/common/DateRangePicker.tsx` — `calculateInitialRange` / `handleOffset` の 1-month ケース

矢印移動（shift）側は、調整後の開始日から未調整の基準日を復元してから境界を再計算するように統一した。

## 確認

- before / after / none の各区分で、隣接期間の差がちょうど1日（重複・欠落なし）になることをシミュレーションで確認
- ← / → の連続移動でも連続性が保たれることを確認
- 両パッケージで `tsc --noEmit` 通過

## Done条件

- [x] モバイル版で前倒し/後倒し時に期間が重複しない
- [x] デスクトップ版で前倒し/後倒し時に期間が重複しない
- [x] 「ずらしなし」および前後移動（←/→）でも連続性が保たれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)