### PR TITLE
fix(全体): ダッシュボードの期間指定がタブ切替で初期値に戻る不具合を修正 #112

### DIFF
--- a/desktop/src/components/common/DateRangePicker.tsx
+++ b/desktop/src/components/common/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import {
   computePeriodRange,
   shiftPeriodRange,
@@ -7,11 +7,22 @@ import type { PeriodPreset, PeriodRange, PeriodSettings } from '@asset-simulator
 
 export type DateRange = PeriodRange;
 
-type HolidayAdjustment = 'none' | 'before' | 'after';
+export type HolidayAdjustment = 'none' | 'before' | 'after';
+
+export interface DateRangeSettings {
+  preset: string;
+  startDayOfWeek: number;
+  startDayOfMonth: number;
+  holidayAdj: HolidayAdjustment;
+  startMonthDay: { m: number; d: number };
+}
 
 interface DateRangePickerProps {
   dateRange: DateRange;
   onDateRangeChange: (dateRange: DateRange) => void;
+  settings: DateRangeSettings;
+  onSettingsChange: (settings: DateRangeSettings) => void;
+  skipInitialCompute?: boolean;
   className?: string;
 }
 
@@ -26,14 +37,13 @@ const PRESET_MAP: Record<string, PeriodPreset> = {
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   dateRange,
   onDateRangeChange,
+  settings,
+  onSettingsChange,
+  skipInitialCompute,
   className = ''
 }) => {
-  // 設定用ステート
-  const [preset, setPreset] = useState<string>('1-month');
-  const [startDayOfWeek, setStartDayOfWeek] = useState<number>(1); // 0:日, 1:月...
-  const [startDayOfMonth, setStartDayOfMonth] = useState<number>(25);
-  const [holidayAdj, setHolidayAdj] = useState<HolidayAdjustment>('before');
-  const [startMonthDay, setStartMonthDay] = useState<{ m: number, d: number }>({ m: 12, d: 25 });
+  // 設定（親からの controlled props）
+  const { preset, startDayOfWeek, startDayOfMonth, holidayAdj, startMonthDay } = settings;
 
   const buildSettings = useCallback((): PeriodSettings => ({
     startDayOfWeek,
@@ -63,12 +73,15 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 
   // 設定項目が変更された時のみ初期計算を実行
   // 依存関係に dateRange を含めないことで、矢印ボタン操作時の上書きループを防ぐ
+  const didMountRef = useRef(false);
   useEffect(() => {
+    const isFirst = !didMountRef.current;
+    didMountRef.current = true;
+    // localStorage 復元値がある再マウント時は初回計算をスキップして保持値を守る
+    if (isFirst && skipInitialCompute) return;
     if (preset !== 'custom') {
       calculateInitialRange();
     }
-    // 依存関係から calculateInitialRange を外すことで、
-    // 親から dateRange (Props) が降ってきても再計算ループが起きないようにする
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preset, startDayOfWeek, startDayOfMonth, holidayAdj, startMonthDay]);
 
@@ -103,8 +116,8 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
         <div className="col-auto">
           <select 
             className="form-select form-select-sm" 
-            value={preset} 
-            onChange={(e) => setPreset(e.target.value)}
+            value={preset}
+            onChange={(e) => onSettingsChange({ ...settings, preset: e.target.value })}
           >
             <option value="custom">カスタム</option>
             <option value="1-week">1週間</option>
@@ -118,8 +131,8 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
           <div className="col-auto">
             <select 
               className="form-select form-select-sm" 
-              value={startDayOfWeek} 
-              onChange={(e) => setStartDayOfWeek(Number(e.target.value))}
+              value={startDayOfWeek}
+              onChange={(e) => onSettingsChange({ ...settings, startDayOfWeek: Number(e.target.value) })}
             >
               {['日', '月', '火', '水', '木', '金', '土'].map((d, i) => (
                 <option key={i} value={i}>{d}曜日</option>
@@ -138,15 +151,15 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 style={{ width: '55px' }} 
                 min="1" 
                 max="31" 
-                value={startDayOfMonth} 
-                onChange={(e) => setStartDayOfMonth(Number(e.target.value))} 
+                value={startDayOfMonth}
+                onChange={(e) => onSettingsChange({ ...settings, startDayOfMonth: Number(e.target.value) })}
               />
             </div>
             <div className="col-auto">
               <select 
                 className="form-select form-select-sm" 
-                value={holidayAdj} 
-                onChange={(e) => setHolidayAdj(e.target.value as HolidayAdjustment)}
+                value={holidayAdj}
+                onChange={(e) => onSettingsChange({ ...settings, holidayAdj: e.target.value as HolidayAdjustment })}
               >
                 <option value="none">休日ずらしなし</option>
                 <option value="before">休日前倒し</option>
@@ -166,8 +179,8 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 style={{ width: '50px' }} 
                 min="1" 
                 max="12" 
-                value={startMonthDay.m} 
-                onChange={(e) => setStartMonthDay({ ...startMonthDay, m: Number(e.target.value) })} 
+                value={startMonthDay.m}
+                onChange={(e) => onSettingsChange({ ...settings, startMonthDay: { ...startMonthDay, m: Number(e.target.value) } })}
               />
               <span>/</span>
               <input 
@@ -176,8 +189,8 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 style={{ width: '50px' }} 
                 min="1" 
                 max="31" 
-                value={startMonthDay.d} 
-                onChange={(e) => setStartMonthDay({ ...startMonthDay, d: Number(e.target.value) })} 
+                value={startMonthDay.d}
+                onChange={(e) => onSettingsChange({ ...settings, startMonthDay: { ...startMonthDay, d: Number(e.target.value) } })}
               />
             </div>
           </div>

--- a/desktop/src/components/journal/JournalDashboard.tsx
+++ b/desktop/src/components/journal/JournalDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useFinancialStore, useAuthStore, BalanceSheetView, ProfitLossView, formatDateLocal } from '@asset-simulator/shared';
-import { DateRangePicker, DateRange } from '../common/DateRangePicker';
+import { DateRangePicker, DateRange, DateRangeSettings } from '../common/DateRangePicker';
 
 export const JournalDashboard: React.FC = () => {
   const { getBalanceSheetView, getProfitLossStatementView } = useFinancialStore();
@@ -18,7 +18,15 @@ export const JournalDashboard: React.FC = () => {
   };
 
   const defaultRange = getInitialRange();
-  
+
+  const defaultDateSettings: DateRangeSettings = {
+    preset: '1-month',
+    startDayOfWeek: 1,
+    startDayOfMonth: 25,
+    holidayAdj: 'before',
+    startMonthDay: { m: 12, d: 25 },
+  };
+
 const getStoredDateRange = (): DateRange => {
     if (!userId) return defaultRange;
     const key = `JournalDashboard-date-range_${userId}`;
@@ -33,15 +41,28 @@ const getStoredDateRange = (): DateRange => {
     return defaultRange;
   };
 
+  const getStoredDateSettings = (): DateRangeSettings => {
+    if (!userId) return defaultDateSettings;
+    const stored = localStorage.getItem(`JournalDashboard-date-settings_${userId}`);
+    if (stored) {
+      try { return { ...defaultDateSettings, ...JSON.parse(stored) }; } catch { return defaultDateSettings; }
+    }
+    return defaultDateSettings;
+  };
+
   const getStoredBsAsOfDate = (plEndDate?: string): string => {
     if (!userId) return plEndDate || defaultRange.endDate;
     const key = `JournalDashboard-bs-as-of-date_${userId}`;
     const stored = localStorage.getItem(key);
     return stored || plEndDate || defaultRange.endDate;
   };
-  
+
   const initialDateRange = getStoredDateRange();
   const [dateRange, setDateRange] = useState<DateRange>(initialDateRange);
+  const [dateSettings, setDateSettings] = useState<DateRangeSettings>(getStoredDateSettings());
+  const hadStoredRangeRef = React.useRef<boolean>(
+    !!userId && localStorage.getItem(`JournalDashboard-date-range_${userId}`) !== null
+  );
   const [bsAsOfDate, setBsAsOfDate] = useState<string>(getStoredBsAsOfDate(initialDateRange.endDate));
   const [bsData, setBsData] = useState<BalanceSheetView[]>([]);
   const [plData, setPlData] = useState<ProfitLossView[]>([]);
@@ -52,6 +73,12 @@ const getStoredDateRange = (): DateRange => {
       localStorage.setItem(`JournalDashboard-date-range_${userId}`, JSON.stringify(dateRange));
     }
   }, [dateRange, userId]);
+
+  useEffect(() => {
+    if (userId) {
+      localStorage.setItem(`JournalDashboard-date-settings_${userId}`, JSON.stringify(dateSettings));
+    }
+  }, [dateSettings, userId]);
 
   useEffect(() => {
     if (userId) {
@@ -186,9 +213,12 @@ const getStoredDateRange = (): DateRange => {
             </div>
             <div className="card-body">
               <div className="col-md-12 mb-3">
-                <DateRangePicker 
+                <DateRangePicker
                   dateRange={dateRange}
                   onDateRangeChange={handleDateRangeChange}
+                  settings={dateSettings}
+                  onSettingsChange={setDateSettings}
+                  skipInitialCompute={hadStoredRangeRef.current}
                   className=''
                 />
               </div>

--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -17,7 +17,7 @@ import { PanelButton } from "@mobile-components/PanelButton";
 import { CommonButton } from "@mobile-components/CommonButton";
 import { Dialog } from "@mobile-components/Dialog";
 import { PeriodSelector } from "@mobile-components/PeriodSelector";
-import { computePeriodRange, DEFAULT_PERIOD_SETTINGS } from "@mobile-components/periodSelector.utils";
+import { computePeriodRange, DEFAULT_PERIOD_SETTINGS, type PeriodPreset, type PeriodSettings } from "@mobile-components/periodSelector.utils";
 import LoginScreen from "./LoginScreen";
 
 type TabId = "transaction" | "pl-bs" | "recurring" | "accounts";
@@ -91,6 +91,9 @@ function App() {
   const [plStartDate, setPlStartDate] = useState(defaults.plStart);
   const [plEndDate, setPlEndDate] = useState(defaults.plEnd);
   const [bsAsOfDate, setBsAsOfDate] = useState(defaults.bsAsOf);
+
+  const [periodPreset, setPeriodPreset] = useState<PeriodPreset>("month");
+  const [periodSettings, setPeriodSettings] = useState<PeriodSettings>(DEFAULT_PERIOD_SETTINGS);
 
   const [plRows, setPlRows] = useState<ProfitLossView[]>([]);
   const [bsRows, setBsRows] = useState<BalanceSheetView[]>([]);
@@ -193,6 +196,10 @@ function App() {
               <PeriodSelector
                 range={{ startDate: plStartDate, endDate: plEndDate }}
                 onChange={(r) => handleDashboardPeriodChange(r.startDate, r.endDate)}
+                preset={periodPreset}
+                onPresetChange={setPeriodPreset}
+                settings={periodSettings}
+                onSettingsChange={setPeriodSettings}
               />
             </div>
 
@@ -211,6 +218,10 @@ function App() {
                   appliedEndDate={plEndDate}
                   rows={plRows}
                   onApply={(s, e) => { setPlStartDate(s); setPlEndDate(e); }}
+                  preset={periodPreset}
+                  onPresetChange={setPeriodPreset}
+                  settings={periodSettings}
+                  onSettingsChange={setPeriodSettings}
                 />
               </div>
             </div>

--- a/mobile/app/src/ProfitLossStatementCard.tsx
+++ b/mobile/app/src/ProfitLossStatementCard.tsx
@@ -2,12 +2,17 @@ import { useMemo, type CSSProperties } from "react";
 import type { ProfitLossView } from "@asset-simulator/shared";
 import { PeriodSelector } from "@mobile-components/PeriodSelector";
 import { DataGrid } from "@mobile-components/DataGrid";
+import type { PeriodPreset, PeriodSettings } from "@mobile-components/periodSelector.utils";
 
 type Props = {
   appliedStartDate: string;
   appliedEndDate: string;
   rows: ProfitLossView[];
   onApply: (startDate: string, endDate: string) => void;
+  preset: PeriodPreset;
+  onPresetChange: (preset: PeriodPreset) => void;
+  settings: PeriodSettings;
+  onSettingsChange: (settings: PeriodSettings) => void;
 };
 
 // 区分の表示順（損益計算書: 収益→費用）
@@ -27,7 +32,16 @@ const container: CSSProperties = {
 };
 
 // 収益・費用サマリーリスト（純利益パネル配下に表示される明細）
-export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows, onApply }: Props) {
+export function ProfitLossStatementCard({
+  appliedStartDate,
+  appliedEndDate,
+  rows,
+  onApply,
+  preset,
+  onPresetChange,
+  settings,
+  onSettingsChange,
+}: Props) {
   // サーバー集計済みの ProfitLossView を表示用の行へマッピング（区分→勘定科目でソート）
   const grouped = useMemo(
     () =>
@@ -56,6 +70,10 @@ export function ProfitLossStatementCard({ appliedStartDate, appliedEndDate, rows
       <PeriodSelector
         range={{ startDate: appliedStartDate, endDate: appliedEndDate }}
         onChange={(r) => onApply(r.startDate, r.endDate)}
+        preset={preset}
+        onPresetChange={onPresetChange}
+        settings={settings}
+        onSettingsChange={onSettingsChange}
       />
       <div>
         <DataGrid

--- a/mobile/components/PeriodSelector.tsx
+++ b/mobile/components/PeriodSelector.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import { SelectInput } from "./SelectInput";
 import { NumericInput } from "./NumericInput";
 import { DateInput } from "./DateInput";
 import {
   computePeriodRange,
   shiftPeriodRange,
-  DEFAULT_PERIOD_SETTINGS,
   type PeriodPreset,
   type PeriodRange,
   type PeriodSettings,
@@ -15,8 +14,10 @@ import {
 interface PeriodSelectorProps {
   range: PeriodRange;
   onChange: (range: PeriodRange) => void;
-  defaultPreset?: PeriodPreset;
-  defaultSettings?: Partial<PeriodSettings>;
+  preset: PeriodPreset;
+  onPresetChange: (preset: PeriodPreset) => void;
+  settings: PeriodSettings;
+  onSettingsChange: (settings: PeriodSettings) => void;
 }
 
 const presetOptions = [
@@ -70,15 +71,11 @@ const styles = {
 export function PeriodSelector({
   range,
   onChange,
-  defaultPreset = "month",
-  defaultSettings,
+  preset,
+  onPresetChange,
+  settings,
+  onSettingsChange,
 }: PeriodSelectorProps) {
-  const [preset, setPreset] = useState<PeriodPreset>(defaultPreset);
-  const [settings, setSettings] = useState<PeriodSettings>(() => ({
-    ...DEFAULT_PERIOD_SETTINGS,
-    ...defaultSettings,
-  }));
-
   // 親が毎レンダーで新しい onChange を渡しても効果が再実行されないよう ref 経由で参照する。
   const onChangeRef = useRef(onChange);
   useEffect(() => {
@@ -87,14 +84,17 @@ export function PeriodSelector({
 
   // プリセット/設定が変わったとき（custom 以外）に範囲を再計算して通知する。
   // range を依存に含めないことで、矢印操作や親の更新による再計算ループを防ぐ。
+  const didMountRef = useRef(false);
   useEffect(() => {
+    // 再マウント時に保持済みの範囲（矢印移動後の値を含む）を初期設定で上書きしないよう、初回実行だけスキップ
+    if (!didMountRef.current) { didMountRef.current = true; return; }
     if (preset === "custom") return;
     const next = computePeriodRange(preset, settings);
     if (next) onChangeRef.current(next);
   }, [preset, settings]);
 
   const updateSetting = <K extends keyof PeriodSettings>(key: K, value: PeriodSettings[K]) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
+    onSettingsChange({ ...settings, [key]: value });
   };
 
   const handleShift = (direction: "prev" | "next") => {
@@ -118,7 +118,7 @@ export function PeriodSelector({
         <SelectInput
           options={presetOptions}
           value={preset}
-          onChange={(v) => setPreset(v as PeriodPreset)}
+          onChange={(v) => onPresetChange(v as PeriodPreset)}
           sizeVariant="S"
           fontSize="S"
         />


### PR DESCRIPTION
## 関連Issue

closes #112

## 変更概要

ダッシュボードの期間指定がタブ切替で初期値に戻る不具合を修正。期間セレクターがタブ切替で再マウントされる際、内部の `preset`・設定 state が初期値に戻り、マウント時の再計算 effect がデフォルト期間を算出して親の保持値を上書きしていたのが原因。

セレクター設定を親へリフトアップ（controlled 化）して保持し、再マウント直後の初回再計算をスキップすることで、期間指定・矢印移動後の値・セレクター設定を保持する。

**デスクトップ**
- `DateRangePicker.tsx` — 5つの内部 state を単一 `settings` prop に集約し controlled 化。`skipInitialCompute` + `didMountRef` で復元値の上書きを防止
- `JournalDashboard.tsx` — `dateSettings` を localStorage (`JournalDashboard-date-settings_${userId}`) に永続化。保存済み期間の有無で `skipInitialCompute` を制御し、初回ロード時のデフォルト算出は維持

**モバイル**
- `PeriodSelector.tsx` — `preset`/`settings` を controlled props 化。`didMountRef` で初回再計算をスキップ
- `App.tsx` — `periodPreset`/`periodSettings` を App state で保持（タブ切替で unmount しないため保持される）。トップと明細カード両方へ共有
- `ProfitLossStatementCard.tsx` — props を追加して内部セレクターへ転送

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない（desktop: `tsc --noEmit` exit 0 / mobile: `vite build` 成功・`eslint .` エラーなし）
- [x] 影響範囲の動作確認済み（矢印移動後の値・セレクター設定もタブ切替で保持、初回ロードのデフォルト算出は従来通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)