### PR TITLE
feat(DB): MyOS 連携用の読み取り専用 Finance API（Supabase Edge Function）を追加 #114

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ asset-simulator/
 │   └── src/        # Storybook エントリー用スキャフォールド
 ├── packages/
 │   └── shared/     # 共有型・ユーティリティ・Zustand ストア
+├── supabase/       # マイグレーション + Edge Functions（MyOS 連携 API 等）
 └── docs/           # 設計ドキュメント
 ```
 
@@ -68,6 +69,7 @@ asset-simulator/
 | 仕訳エントリー | `je_` | `je_<uuid>` |
 | 定期仕訳 | `reg_` | `reg_<uuid>` |
 | スケジュールイベント | `event_` | `event_<uuid>` |
+| APIトークン | `tok_` | `tok_<uuid>` |
 
 ## セキュリティルール
 
@@ -83,6 +85,7 @@ asset-simulator/
 | `docs/architecture/overview.md` | システム概要・技術スタック・ディレクトリ構成・状態管理・shared/utils |
 | `docs/ui/specification.md` | 画面構成・コンポーネント仕様・フォームバリデーション・データフロー・期間セレクター仕様 |
 | `docs/api/specification.md` | Supabase 直接アクセスの規約・テーブル/VIEW/RPC 一覧・ストアアクション一覧 |
+| `docs/api/myos_integration.md` | MyOS 連携用の読み取り専用 Finance API（Edge Function）仕様 |
 | `docs/database/er_diagram.puml` | DB ER 図（PlantUML） |
 | `docs/database/schema.md` | テーブル定義・カラム説明・VIEW・RPC |
 | `docs/test/scenarios.md` | 自動テストの観点一覧・手動テストシナリオ・回帰観点 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Asset Simulator の設計ドキュメント一覧です。API サーバー（Exp
 | ファイル | 内容 |
 |---------|------|
 | [api/specification.md](api/specification.md) | Supabase 直接アクセスの規約・テーブル/VIEW/RPC 一覧・ストアアクション一覧・定期取引実行仕様 |
+| [api/myos_integration.md](api/myos_integration.md) | MyOS 連携用の読み取り専用 Finance API（Edge Function）仕様・トークン発行・デプロイ手順 |
 
 ## DB・ER設計
 

--- a/docs/api/myos_integration.md
+++ b/docs/api/myos_integration.md
@@ -1,0 +1,103 @@
+# MyOS 連携用 Finance API（読み取り専用）
+
+> 隣接プロジェクト MyOS（GitHub Pages 配信の PWA）から、家計データを読み取り専用で参照するための Supabase Edge Function。
+> MyOS 側の契約は MyOS リポジトリの `docs/feature/finance_integration.md` を参照。
+
+## 概要
+
+- 実体: Supabase Edge Function `supabase/functions/myos/index.ts`（Deno）
+- MyOS は書き込みを行わず、サマリ・カテゴリ内訳・大口イベントの取得のみ行う
+- 認証は Supabase Auth の JWT ではなく、専用の API トークン（`api_tokens` テーブル）による Bearer 認証
+- データソースは既存の RPC `fn_profit_loss` および `journal_entries` / `journal_accounts` テーブル（service role で参照するため RLS はバイパスされる。そのため `p_user_id` / `user_id` フィルタを Edge Function 側で必ず指定する）
+
+## 認証とトークン発行
+
+- `api_tokens` テーブル（`supabase/migrations/20260705000000_myos_api_tokens.sql`）に SHA-256 ハッシュのみ保存する。平文は保存しない。
+- 発行は Supabase SQL Editor（postgres / service role）から `fn_issue_api_token` を実行する。
+
+  ```sql
+  select fn_issue_api_token('<auth.users の uuid>', 'myos');
+  ```
+
+  戻り値の `ast_...` が平文トークン。**この結果はこの一度しか表示されない**ため、MyOS の設定画面にその場で貼り付けること。
+- 失効はレコード削除で行う。
+
+  ```sql
+  delete from api_tokens where id = '<tok_...>';
+  ```
+
+- リクエストは `Authorization: Bearer <ast_...>` ヘッダを付与する。
+
+## エンドポイント仕様
+
+ベース URL: `https://<project-ref>.supabase.co/functions/v1/myos`
+
+### `GET /summary?month=YYYY-MM`
+
+当月の収入・支出・収支サマリ。
+
+```json
+{ "month": "2026-07", "income": 320000, "expense": 277700, "net": 42300 }
+```
+
+- `income` = `fn_profit_loss` の `category = 'Revenue'` 行の `sum_amount` 合計
+- `expense` = 同 `category = 'Expense'` 行の合計
+- `net` = `income - expense`
+
+### `GET /categories?month=YYYY-MM`
+
+支出のカテゴリ（勘定科目）別内訳。金額降順。
+
+```json
+{ "month": "2026-07", "categories": [ { "name": "食費", "amount": 48200 } ] }
+```
+
+### `GET /events?range=YYYY-MM-DD..YYYY-MM-DD&min_amount=N`
+
+指定期間の大口支出イベント。借方勘定科目が `Expense` カテゴリの仕訳のみを対象とし、金額は負値で返す。`min_amount` は絞り込み下限（省略時 0）。
+
+```json
+{ "events": [ { "date": "2026-07-02", "title": "家賃", "amount": -95000 } ] }
+```
+
+### エラーコード
+
+| コード | 意味 |
+|-------|------|
+| 400 | パラメータ不正（`month` / `range` / `min_amount` の形式エラー） |
+| 401 | トークン不正・未指定 |
+| 404 | 未定義のパス |
+| 500 | サーバー内部エラー（DB エラー含む） |
+
+MyOS 側は 401/403 を「トークンを確認してください」、5xx・タイムアウトを「取得できませんでした」として扱う想定（MyOS 側実装）。
+
+## デプロイ手順
+
+1. マイグレーション適用（`api_tokens` テーブル・`fn_issue_api_token` 関数の作成）
+
+   ```sh
+   supabase db push
+   ```
+
+   または SQL Editor で `supabase/migrations/20260705000000_myos_api_tokens.sql` の内容を直接実行する。
+
+2. Edge Function をデプロイ。独自の Bearer トークン認証を行うため、Supabase 標準の JWT 検証は無効化する。
+
+   ```sh
+   supabase functions deploy myos --no-verify-jwt --project-ref <project-ref>
+   ```
+
+3. CORS 許可オリジンを設定（GitHub Pages のオリジン）。
+
+   ```sh
+   supabase secrets set MYOS_ALLOWED_ORIGINS=https://<user>.github.io
+   ```
+
+   未設定の場合、Edge Function は CORS ヘッダを一切付与しない（ブラウザからの呼び出しは失敗する）。
+
+## セキュリティ注意
+
+- API トークンは平文を保存しない。DB には SHA-256 ハッシュのみ保持する。
+- リクエストログ・エラーログにトークン平文・ハッシュを出力しない。
+- 本 API は読み取り専用（GET のみ）。書き込みエンドポイントは提供しない。
+- `fn_issue_api_token` は `anon` / `authenticated` ロールに EXECUTE 権限を与えていない（SQL Editor からのみ実行可能）。

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -107,6 +107,23 @@ ER 図: [er_diagram.puml](er_diagram.puml)
 
 ---
 
+### api_tokens（MyOS 連携用 API トークン）
+
+MyOS からの読み取り専用連携用。詳細は [`docs/api/myos_integration.md`](../api/myos_integration.md)。
+
+| カラム | 型 | 説明 |
+|-------|---|------|
+| id | string PK | `tok_<uuid>` |
+| user_id | uuid FK→auth.users | — |
+| name | string | トークン用途名（例: `myos`） |
+| token_hash | string | 平文トークンの SHA-256 hex ハッシュ（一意）。平文は保存しない |
+| created_at | timestamp | — |
+| last_used_at | timestamp \| null | Edge Function 認証成功のたびに更新 |
+
+発行は SECURITY DEFINER 関数 `fn_issue_api_token(p_user_id, p_name)` を SQL Editor から実行する（`anon` / `authenticated` には EXECUTE 権限なし）。RLS は「本人のみ select 可」のみで insert/update/delete ポリシーは設けていない。
+
+---
+
 ## VIEW
 
 ### v_journal_entries_for_calendar

--- a/supabase/functions/myos/index.ts
+++ b/supabase/functions/myos/index.ts
@@ -1,0 +1,212 @@
+// MyOS 連携用の読み取り専用 Finance API（Issue #114）
+// エンドポイント: GET /summary, GET /categories, GET /events
+// 認証: Authorization: Bearer <ast_...> トークン（api_tokens.token_hash で照合）
+
+import { createClient } from 'npm:@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const ALLOWED_ORIGINS = (Deno.env.get('MYOS_ALLOWED_ORIGINS') ?? '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+const MONTH_RE = /^\d{4}-\d{2}$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  if (!origin || !ALLOWED_ORIGINS.includes(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    Vary: 'Origin',
+    'Access-Control-Allow-Headers': 'authorization, content-type',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  };
+}
+
+function json(body: unknown, status: number, cors: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...cors },
+  });
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const data = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// month='YYYY-MM' → [YYYY-MM-01, YYYY-MM-末日]（日付文字列を手組みし TZ ずれを避ける）
+function monthRange(month: string): { start: string; end: string } {
+  const [yearStr, monthStr] = month.split('-');
+  const year = Number(yearStr);
+  const mon = Number(monthStr);
+  const lastDay = new Date(year, mon, 0).getDate();
+  return {
+    start: `${yearStr}-${monthStr}-01`,
+    end: `${yearStr}-${monthStr}-${pad2(lastDay)}`,
+  };
+}
+
+Deno.serve(async (req) => {
+  const cors = corsHeaders(req.headers.get('origin'));
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  // 認証: Bearer トークンを SHA-256 ハッシュ化して api_tokens と照合
+  const authHeader = req.headers.get('authorization') ?? '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    return json({ error: 'unauthorized' }, 401, cors);
+  }
+
+  let userId: string;
+  let tokenId: string;
+  try {
+    const tokenHash = await sha256Hex(match[1]);
+    const { data: tokenRow } = await supabase
+      .from('api_tokens')
+      .select('id, user_id')
+      .eq('token_hash', tokenHash)
+      .maybeSingle();
+
+    if (!tokenRow) {
+      return json({ error: 'unauthorized' }, 401, cors);
+    }
+    userId = tokenRow.user_id;
+    tokenId = tokenRow.id;
+  } catch (err) {
+    console.error('myos: auth lookup failed', err);
+    return json({ error: 'internal error' }, 500, cors);
+  }
+
+  // last_used_at 更新は結果を待たず失敗も無視する
+  supabase
+    .from('api_tokens')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', tokenId)
+    .then(undefined, () => {});
+
+  const url = new URL(req.url);
+  const route = url.pathname.replace(/^.*\/myos\/?/, '');
+
+  if (!['summary', 'categories', 'events'].includes(route)) {
+    return json({ error: 'not found' }, 404, cors);
+  }
+  if (req.method !== 'GET') {
+    return json({ error: 'method not allowed' }, 405, cors);
+  }
+
+  try {
+    if (route === 'summary') {
+      return await handleSummary(url, userId, cors);
+    }
+    if (route === 'categories') {
+      return await handleCategories(url, userId, cors);
+    }
+    return await handleEvents(url, userId, cors);
+  } catch (err) {
+    console.error('myos: request failed', err);
+    return json({ error: 'internal error' }, 500, cors);
+  }
+});
+
+async function handleSummary(url: URL, userId: string, cors: Record<string, string>): Promise<Response> {
+  const month = url.searchParams.get('month') ?? '';
+  if (!MONTH_RE.test(month)) {
+    return json({ error: 'invalid month' }, 400, cors);
+  }
+  const { start, end } = monthRange(month);
+
+  const { data, error } = await supabase.rpc('fn_profit_loss', {
+    p_start_date: start,
+    p_end_date: end,
+    p_user_id: userId,
+  });
+  if (error) throw error;
+
+  let income = 0;
+  let expense = 0;
+  for (const row of data ?? []) {
+    if (row.category === 'Revenue') income += Number(row.sum_amount);
+    if (row.category === 'Expense') expense += Number(row.sum_amount);
+  }
+
+  return json({ month, income, expense, net: income - expense }, 200, cors);
+}
+
+async function handleCategories(url: URL, userId: string, cors: Record<string, string>): Promise<Response> {
+  const month = url.searchParams.get('month') ?? '';
+  if (!MONTH_RE.test(month)) {
+    return json({ error: 'invalid month' }, 400, cors);
+  }
+  const { start, end } = monthRange(month);
+
+  const { data, error } = await supabase.rpc('fn_profit_loss', {
+    p_start_date: start,
+    p_end_date: end,
+    p_user_id: userId,
+  });
+  if (error) throw error;
+
+  const categories = (data ?? [])
+    .filter((row: { category: string }) => row.category === 'Expense')
+    .map((row: { name: string; sum_amount: number }) => ({ name: row.name, amount: Number(row.sum_amount) }))
+    .sort((a: { amount: number }, b: { amount: number }) => b.amount - a.amount);
+
+  return json({ month, categories }, 200, cors);
+}
+
+async function handleEvents(url: URL, userId: string, cors: Record<string, string>): Promise<Response> {
+  const range = url.searchParams.get('range') ?? '';
+  const parts = range.split('..');
+  if (parts.length !== 2 || !DATE_RE.test(parts[0]) || !DATE_RE.test(parts[1]) || parts[0] > parts[1]) {
+    return json({ error: 'invalid range' }, 400, cors);
+  }
+  const [startDate, endDate] = parts;
+
+  const minAmountParam = url.searchParams.get('min_amount');
+  const minAmount = minAmountParam === null ? 0 : Number(minAmountParam);
+  if (Number.isNaN(minAmount)) {
+    return json({ error: 'invalid min_amount' }, 400, cors);
+  }
+
+  const { data: accounts, error: accountsError } = await supabase
+    .from('journal_accounts')
+    .select('id, category')
+    .eq('user_id', userId);
+  if (accountsError) throw accountsError;
+
+  const categoryByAccountId = new Map<string, string>((accounts ?? []).map((a: { id: string; category: string }) => [a.id, a.category]));
+
+  const { data: entries, error: entriesError } = await supabase
+    .from('journal_entries')
+    .select('date, description, amount, debit_account_id')
+    .eq('user_id', userId)
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .gte('amount', minAmount)
+    .order('date', { ascending: true });
+  if (entriesError) throw entriesError;
+
+  const events = (entries ?? [])
+    .filter((e: { debit_account_id: string }) => categoryByAccountId.get(e.debit_account_id) === 'Expense')
+    .map((e: { date: string; description: string; amount: number }) => ({
+      date: e.date,
+      title: e.description,
+      amount: -Number(e.amount),
+    }));
+
+  return json({ events }, 200, cors);
+}

--- a/supabase/migrations/20260705000000_myos_api_tokens.sql
+++ b/supabase/migrations/20260705000000_myos_api_tokens.sql
@@ -1,0 +1,50 @@
+-- MyOS 連携用の読み取り専用 API トークン管理
+-- Issue #114: MyOS（別リポジトリの PWA）から Finance Edge Function を Bearer トークンで叩けるようにする
+
+create extension if not exists pgcrypto;
+
+-- API トークン本体は保存せず、SHA-256 ハッシュのみを保持する
+create table if not exists api_tokens (
+  id text primary key default ('tok_' || gen_random_uuid()),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  token_hash text not null unique,
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz
+);
+
+comment on table api_tokens is 'MyOS 等の外部連携向け読み取り専用 API トークン。平文は発行時のみ返却し、以降は token_hash（SHA-256）で照合する。';
+comment on column api_tokens.token_hash is 'encode(digest(平文トークン, ''sha256''), ''hex'')';
+comment on column api_tokens.last_used_at is 'Edge Function から認証成功のたびに更新（失敗しても無視）';
+
+alter table api_tokens enable row level security;
+
+-- 本人のみ自分のトークン一覧を参照可能。発行・失効は SECURITY DEFINER 関数 / service role 経由のみとし、
+-- insert/update/delete ポリシーはあえて設けない。
+create policy "api_tokens_select_own" on api_tokens
+  for select
+  using (auth.uid() = user_id);
+
+-- Supabase SQL Editor（postgres / service role）から手動実行し、API トークンを発行する。
+-- 平文トークンはこの戻り値でのみ確認できる（以降は再表示不可）。
+create or replace function fn_issue_api_token(p_user_id uuid, p_name text)
+returns text
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_token text;
+begin
+  v_token := 'ast_' || encode(gen_random_bytes(32), 'hex');
+
+  insert into api_tokens (user_id, name, token_hash)
+  values (p_user_id, p_name, encode(digest(v_token, 'sha256'), 'hex'));
+
+  return v_token;
+end;
+$$;
+
+comment on function fn_issue_api_token(uuid, text) is 'API トークンを発行し平文を一度だけ返す。SQL Editor からのみ実行可能（anon/authenticated には EXECUTE を許可しない）。';
+
+revoke execute on function fn_issue_api_token(uuid, text) from public, anon, authenticated;


### PR DESCRIPTION
## 関連Issue

closes #114

## 変更概要

MyOS（GitHub Pages 配信の PWA）から取引情報を読み取り専用で参照するための API を、Supabase Edge Function として追加。MyOS 側の連携設計（`my-os/docs/feature/finance_integration.md`）の契約に合わせている。

- `supabase/migrations/20260705000000_myos_api_tokens.sql`
  - `api_tokens` テーブル（トークンは SHA-256 ハッシュのみ保存・RLS 有効・本人 select のみ）
  - 発行用 SECURITY DEFINER 関数 `fn_issue_api_token(p_user_id, p_name)`（`anon`/`authenticated` の EXECUTE 権限は剥奪。SQL Editor からのみ実行）
- `supabase/functions/myos/index.ts`（Edge Function・Deno）
  - `GET /summary?month=YYYY-MM` — 月次収支サマリ（既存 RPC `fn_profit_loss` を利用、income/expense/net の定義は desktop の財務ダッシュボードと同一）
  - `GET /categories?month=YYYY-MM` — 費用勘定科目別内訳（金額降順）
  - `GET /events?range=YYYY-MM-DD..YYYY-MM-DD&min_amount=N` — 期間内の支出取引（借方が Expense の仕訳、金額は負値）
  - Bearer トークン認証（ハッシュ照合・`last_used_at` 更新・平文はログに出さない）
  - CORS は環境変数 `MYOS_ALLOWED_ORIGINS` の許可リスト方式
  - 400/401/404/405/500 のエラーハンドリング
- ドキュメント
  - `docs/api/myos_integration.md` を新規追加（仕様・トークン発行手順・デプロイ手順・セキュリティ注意）
  - `docs/README.md` / `docs/database/schema.md` / `CLAUDE.md` を追従更新（`supabase/` ディレクトリ、ID プレフィックス `tok_` 追加）

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない（Edge Function は TypeScript パーサでの構文チェックのみ。deno / supabase CLI が手元にないため、型チェックはデプロイ時に Supabase 側で実施される）
- [x] 影響範囲の動作確認済み（既存フロントコードは無変更。`packages/shared` のテスト 44 件パス。desktop の `App.test.tsx` の失敗は main でも再現する既存の Jest ESM 設定問題で本PRとは無関係）

## デプロイ（マージ後に手動で実施）

```sh
supabase db push   # または SQL Editor で migrations の SQL を実行
supabase functions deploy myos --no-verify-jwt --project-ref <project-ref>
supabase secrets set MYOS_ALLOWED_ORIGINS=https://<user>.github.io
```

トークン発行: SQL Editor で `select fn_issue_api_token('<auth.users の uuid>', 'myos');` → 戻り値（一度だけ表示）を MyOS の設定画面へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
