### PR TITLE
【全体 / 不具合修正】goals テーブルの journal_accounts FK を複合キー参照に修正

### DIFF
--- a/supabase/migrations/20260714010000_goals.sql
+++ b/supabase/migrations/20260714010000_goals.sql
@@ -4,11 +4,12 @@
 create table if not exists goals (
   id text primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  account_id text not null references journal_accounts(id) on delete cascade,
+  account_id text not null,
   period text not null check (period in ('day', 'month')),
   amount numeric not null check (amount >= 0),
   created_at timestamptz not null default now(),
-  unique (user_id, account_id, period)
+  unique (user_id, account_id, period),
+  foreign key (account_id, user_id) references journal_accounts (id, user_id) on delete cascade
 );
 
 comment on table goals is '勘定科目ごと・期間（日次/月次）ごとの支出目標。id はクライアント側で goal_<uuid> 形式を発行する。';


### PR DESCRIPTION
## 関連Issue

closes #122

## 変更概要

`journal_accounts` の主キーは複合キー `(id, user_id)` であり、`id` 単独には UNIQUE 制約がないため、`supabase/migrations/20260714010000_goals.sql` の `goals.account_id` が `references journal_accounts(id)` と単一カラムで参照していると `supabase db push` が以下のエラーで失敗していた。

```
ERROR: there is no unique constraint matching given keys for referenced table "journal_accounts" (SQLSTATE 42830)
```

既存の `journal_entries` / `regular_journal_entries` と同様に、`goals` テーブルの FK を複合 FK `(account_id, user_id) → journal_accounts(id, user_id)` に修正した。

- `account_id` カラムの単一カラム `references` を削除
- テーブル末尾に `foreign key (account_id, user_id) references journal_accounts (id, user_id) on delete cascade` を追加

## 確認項目

- [x] Done条件をすべて満たしている（FK を複合キー参照に修正）
- [x] 型エラー・lintエラーがない（SQL migration のみの変更）
- [ ] 影響範囲の動作確認済み（`supabase db push` はこのセッションでは Supabase CLI・DB 接続がなく実行不可のため未確認。リモート環境での適用確認が必要）


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkaZLxBs58hev2k2rvvciG)_