### PR TITLE
【全体 / 改善】Web版Claude Code用にSupabaseホスト型MCP設定を追加 #132

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "supabase-staging": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=gjzulhcfrzpwjaxnrwvi"
+    },
+    "supabase-prod-readonly": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=dfqtsogrhkrayfixnbtz&read_only=true"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Web版 Claude Code（claude.ai/code）から Supabase を操作できるよう、公式ホスト型リモート MCP サーバー（OAuth 認証）の設定 `.mcp.json` を追加する。

## 変更内容

| サーバー | project_ref | 権限 |
|---|---|---|
| `supabase-staging` | `gjzulhcfrzpwjaxnrwvi`（asset-simulator-staging） | 書き込み可 |
| `supabase-prod-readonly` | `dfqtsogrhkrayfixnbtz`（asset-simulator） | `read_only=true` |

- 認証は接続時の OAuth フローのため、トークン・パスワード等のシークレットはコミット不要
- 本番への書き込みは prompt injection 対策として MCP では不許可（migration の正規適用は従来どおり CLI の `db push`）
- project_ref は公開識別子（フロントの接続先 URL に含まれる）のため PUBLIC リポジトリへのコミット可

closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)