### PR TITLE
【モバイル / 不具合修正】取引入力の「よく使う入力」を登録ボタンの下に移動 #136

### DIFF
--- a/docs/ui/specification.md
+++ b/docs/ui/specification.md
@@ -105,7 +105,7 @@ App (desktop/src/App.tsx)
 | `App` | `mobile/app/src/App.tsx` | 認証監視・タブ切り替え・PL/BS 期間の一括管理・支出目標用の月次期間（`goalMonthRange`）の導出（月単位プリセット選択中は表示中の期間、それ以外は期間設定に基づく現在の月次期間）・取引入力/編集ダイアログの開閉 | `getJournalAccounts`, `getRegularJournalEntries`, `fetchEvents`, `getProfitLossStatementView`, `getBalanceSheetView` |
 | `LoginScreen` | `LoginScreen.tsx` | 未ログイン時のログイン画面（Supabase Auth UI） | なし（`useAuthStore` の `client` のみ） |
 | `CalendarCard` | `CalendarCard.tsx` | 月表示のカレンダー。日付タップで選択、ダブルタップで取引入力ダイアログを開く。選択日の取引一覧・編集/削除 | `getCalendarJournalEntries`, `deleteJournalEntry` |
-| `TransactionEntryCard` | `TransactionEntryCard.tsx` | 取引の新規登録／編集（`entry` props の有無でモード切替）。新規登録モードでは「よく使う入力」サジェスト（直近仕訳の頻出セット）をダイアログ上部に表示し、タップで摘要・借方・貸方・金額をフォームに反映 | `addJournalEntry`, `updateJournalEntry`, `getJournalAccounts`（残高反映のため再取得）, `getFrequentJournalEntrySets`（新規モードのみ） |
+| `TransactionEntryCard` | `TransactionEntryCard.tsx` | 取引の新規登録／編集（`entry` props の有無でモード切替）。新規登録モードでは「よく使う入力」サジェスト（直近仕訳の頻出セット）を登録ボタンの下に表示し、タップで摘要・借方・貸方・金額をフォームに反映 | `addJournalEntry`, `updateJournalEntry`, `getJournalAccounts`（残高反映のため再取得）, `getFrequentJournalEntrySets`（新規モードのみ） |
 | `ProfitLossStatementCard` | `ProfitLossStatementCard.tsx` | 収益・費用の明細サマリーリスト（`PeriodSelector` 内包） | なし（`rows` は `App` から props で受け取る） |
 | `BalanceSheetCard` | `BalanceSheetCard.tsx` | 資産・負債・純資産の明細サマリーリスト（基準日プリセット: 今日/今月末/先月末） | なし（`rows` は props） |
 | `RecurringTransactionCard` | `RecurringTransactionCard.tsx` | 定期取引の一覧・追加（ダイアログ）・実行・削除・期限到来分一括実行 | `addRegularJournalEntry`, `deleteRegularJournalEntry`, `executeRegularJournalEntry`, `executeDueRegularJournalEntries` |

--- a/mobile/app/src/TransactionEntryCard.tsx
+++ b/mobile/app/src/TransactionEntryCard.tsx
@@ -155,41 +155,6 @@ export default function TransactionEntryCard({
     >
       <CardBodyMain>
         <div style={{ display: "grid", gap: 12 }}>
-          {!isEditMode && suggestions.length > 0 && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <div style={{ fontSize: 13, color: "#6B7280", textAlign: "left" }}>よく使う入力</div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-                {suggestions.map((s) => (
-                  <button
-                    key={`${s.description}-${s.debitAccountId}-${s.creditAccountId}-${s.amount}`}
-                    type="button"
-                    onClick={() => applySuggestion(s)}
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "flex-start",
-                      gap: 2,
-                      padding: "6px 10px",
-                      borderRadius: 8,
-                      border: "1px solid #BFDBFE",
-                      background: "#EFF6FF",
-                      color: "#1F2937",
-                      fontSize: 13,
-                      cursor: "pointer",
-                      textAlign: "left",
-                    }}
-                  >
-                    <span style={{ fontWeight: 600 }}>
-                      {s.description} ¥{s.amount.toLocaleString()}
-                    </span>
-                    <span style={{ fontSize: 11, color: "#6B7280" }}>
-                      {accountNameById.get(s.debitAccountId) ?? "不明"} / {accountNameById.get(s.creditAccountId) ?? "不明"}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             <DateInput value={date} onChange={setDate} sizeVariant="M" />
             <TextInput
@@ -241,6 +206,41 @@ export default function TransactionEntryCard({
             sizeVariant="S"
             onClick={isEditMode ? updateEntry : registerEntry}
           />
+          {!isEditMode && suggestions.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <div style={{ fontSize: 13, color: "#6B7280", textAlign: "left" }}>よく使う入力</div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                {suggestions.map((s) => (
+                  <button
+                    key={`${s.description}-${s.debitAccountId}-${s.creditAccountId}-${s.amount}`}
+                    type="button"
+                    onClick={() => applySuggestion(s)}
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                      gap: 2,
+                      padding: "6px 10px",
+                      borderRadius: 8,
+                      border: "1px solid #BFDBFE",
+                      background: "#EFF6FF",
+                      color: "#1F2937",
+                      fontSize: 13,
+                      cursor: "pointer",
+                      textAlign: "left",
+                    }}
+                  >
+                    <span style={{ fontWeight: 600 }}>
+                      {s.description} ¥{s.amount.toLocaleString()}
+                    </span>
+                    <span style={{ fontSize: 11, color: "#6B7280" }}>
+                      {accountNameById.get(s.debitAccountId) ?? "不明"} / {accountNameById.get(s.creditAccountId) ?? "不明"}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </CardBodyMain>
     </Card>


### PR DESCRIPTION
## 関連Issue

closes #136

## 変更概要

取引入力ダイアログ（`mobile/app/src/TransactionEntryCard.tsx`）で、上部に表示していた「よく使う入力」サジェストのブロックを、登録ボタンの下へ移動しました。

- `mobile/app/src/TransactionEntryCard.tsx`: サジェスト一覧の JSX ブロックを、フォーム（日付・摘要・借方・貸方・金額）と `CommonButton` の後ろへ移設。表示条件（新規登録モードかつサジェストあり）・スタイル・`applySuggestion` の挙動は変更なし。
- `docs/ui/specification.md`: `TransactionEntryCard` の説明を「ダイアログ上部に表示」→「登録ボタンの下に表示」に更新。

編集モード（`entry` props あり）ではもともとサジェストを表示しないため、挙動に変化はありません。

## 確認項目

- [x] Done条件をすべて満たしている（Issue本文のDone条件は空欄のため、「目標の挙動」＝登録ボタンの下側に表示、を満たすことで判断）
- [x] 型エラー・lintエラーがない（`npx tsc -b` / `npx eslint app/src/TransactionEntryCard.tsx` ともにエラーなし）
- [ ] 影響範囲の動作確認済み（実機/エミュレータでの表示確認は未実施）

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5MvKW5PGEtHckJMFytPjk)_