### PR TITLE
fix(モバイル): mobile/app の tsconfig に paths を追加し型検査対象に含める #142

### DIFF
--- a/mobile/app/tsconfig.app.json
+++ b/mobile/app/tsconfig.app.json
@@ -7,6 +7,15 @@
     "types": ["vite/client"],
     "skipLibCheck": true,
 
+    /* Path mapping: TypeScript は Vite の resolve.alias を読まないため、
+       mobile/vite.config.ts のエイリアスをここにも書かないと TS2307 になる。
+       shared は mobile/tsconfig.app.json と同様、実行時は vite alias でソース参照、
+       型検査はビルド済み dist 宣言を参照する（mobile 側の strict 設定を shared に波及させないため）。 */
+    "paths": {
+      "@mobile-components/*": ["../components/*"],
+      "@asset-simulator/shared": ["../../packages/shared/dist/index"]
+    },
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -21,5 +30,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "../web-new/.storybook/DataGrid.stories.tsx", "../web-new/.storybook/DateInput.stories.tsx", "../web-new/.storybook/NumericInput.stories.tsx", "../web-new/.storybook/SelectInput.stories.tsx", "../web-new/.storybook/TextInput.stories.tsx", "../web-new/.storybook/CommonButton.stories.tsx", "../web-new/.storybook/Card.stories.tsx"]
+  "include": ["src"]
 }

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./app/tsconfig.app.json" }
   ]
 }


### PR DESCRIPTION
closes #142

## 原因

`@mobile-components` エイリアスは `mobile/vite.config.ts` の `resolve.alias` にしか定義されておらず、
TypeScript は Vite の alias を読まない。`mobile/app/tsconfig.app.json` に `paths` が一つも無いため
IDE で `TS2307: Cannot find module '@mobile-components/PanelButton'` になっていた。
`vite build` は alias で解決できるため通ってしまい、気付きにくい状態だった。

さらに `mobile/app/tsconfig.app.json` は `mobile/tsconfig.json` の `references` に含まれていなかったため、
`npm run build`（`tsc -b`）でも検査されていなかった。

## 変更内容

- `mobile/app/tsconfig.app.json` に `paths` を追加
  - `@mobile-components/*` → `../components/*`
  - `@asset-simulator/shared` → `../../packages/shared/dist/index`
- 存在しない `include` パス（`../web-new/.storybook/*.stories.tsx`、`mobile/web-new` は実在しない）を削除
- `mobile/tsconfig.json` の `references` に `./app/tsconfig.app.json` を追加

## 実装メモ

- `baseUrl` は TypeScript 6.0 で deprecated（`TS5101`）のため使わず、`paths` を tsconfig からの相対パスで記述した
- `@asset-simulator/shared` はソース（`src/index.ts`）ではなく `dist` の宣言を参照する。
  ソース参照にすると mobile 側の `verbatimModuleSyntax` / `noUnusedLocals` が shared のソースに適用され、
  shared 側で 13 件のエラーが出るため。既存の `mobile/tsconfig.app.json` と同じ方針に揃えた

## 確認

- `tsc --noEmit -p app/tsconfig.app.json` → エラー0件（修正前は `TS2307` 等が多数）
- `npm run build`（`tsc -b && vite build`）→ exit 0
- `eslint .` → exit 0
- `mobile/app/src` に意図的な型エラーを置いて `tsc -b` が exit 2 で失敗することを確認（検査対象に入ったことの裏取り）

## 補足（本PRの対象外）

`packages/shared/dist` は gitignore 対象で、`mobile` は npm workspaces に含まれないため
`turbo run build` の `^build` でも自動ビルドされない。dist が古い／無い状態では
`Module '"@asset-simulator/shared"' has no exported member 'Goal'` 等が出る
（本PRの検証時も `packages/shared` を手動ビルドして解消した）。
shared のビルドを mobile の前段に繋ぐ対応は、スコープが異なるため別Issueに切り出したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)