### PR TITLE
refactor(全体): useFinancialStore の state / アクション境界を整理 #144

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ asset-simulator/
 - `authStore.ts` — Supabase 認証セッション
 
 **リフレッシュルール**: ミューテーション後は変更したリソースのアクションだけを呼ぶ。  
-`getJournalAccounts()`, `getRegularJournalEntries()` 等を個別に呼ぶこと。  
+`fetchJournalAccounts()`, `fetchRegularJournalEntries()` 等を個別に呼ぶこと。  
 広範囲な「全データ再取得」関数は持たない。
 
 ### shared パッケージの分離ルール
@@ -46,6 +46,7 @@ asset-simulator/
 | `types/`    | 型定義のみ（ロジックなし） |
 | `utils/`    | ユーティリティ関数（`caseConvert.ts` 等） |
 | `stores/`   | Zustand ストア |
+| `queries/`  | Supabase から取得するだけで state を持たない読み取りクエリ（素の async 関数。ストアの `fetchXxx` アクションとは別物） |
 
 `types/common.ts` に変換関数を追加しないこと。
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -20,8 +20,8 @@ type Tab = 'JournalDashboard' | 'transactions' | 'masters' | 'recurring' | 'even
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>('transactions');
   const transactionGroupActive = activeTab === 'transactions' || activeTab === 'recurring';
-  const getJournalAccounts = useFinancialStore((state) => state.getJournalAccounts);
-  const getRegularJournalEntries = useFinancialStore((state) => state.getRegularJournalEntries);
+  const fetchJournalAccounts = useFinancialStore((state) => state.fetchJournalAccounts);
+  const fetchRegularJournalEntries = useFinancialStore((state) => state.fetchRegularJournalEntries);
   const fetchEvents = useEventsStore((state) => state.fetchEvents);
   const { session, client, setSession, refreshSession, signOut } = useAuthStore();
 
@@ -55,12 +55,12 @@ function App() {
   useEffect(() => {
     if (!session) return;
     if (!hasFetchedFinancialRef.current) {
-      getJournalAccounts();
-      getRegularJournalEntries();
+      fetchJournalAccounts();
+      fetchRegularJournalEntries();
       hasFetchedFinancialRef.current = true;
     }
     fetchEvents();
-  }, [session, fetchEvents, getJournalAccounts, getRegularJournalEntries]);
+  }, [session, fetchEvents, fetchJournalAccounts, fetchRegularJournalEntries]);
 
   // タブ切り替え時の追加データ更新
   const prevTabRef = useRef<Tab | null>(null);

--- a/desktop/src/components/MainCalendar.tsx
+++ b/desktop/src/components/MainCalendar.tsx
@@ -4,16 +4,16 @@ import 'react-calendar/dist/Calendar.css';
 import './MainCalendar.css';
 import './utilities.css';
 import './cards.css';
-import { useFinancialStore, useEventsStore, formatDateLocal } from '@asset-simulator/shared';
+import { useFinancialStore, useEventsStore, fetchCalendarJournalEntries, formatDateLocal } from '@asset-simulator/shared';
 import type { CalendarJournalEntry, JournalEntry, ScheduleEvent } from '@asset-simulator/shared';
 import { JournalEntriesModal } from './journal/JournalEntriesModal';
 
 type CalendarTileProps = TileArgs;
 
 export const MainCalendar: React.FC = () => {
-  const { journalAccounts } = useFinancialStore();
-  const { updateJournalEntry, getCalendarJournalEntries } = useFinancialStore();
-  const { events } = useEventsStore();
+  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
+  const updateJournalEntry = useFinancialStore((s) => s.updateJournalEntry);
+  const events = useEventsStore((s) => s.events);
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [currentMonth, setCurrentMonth] = useState<{ year: number; month: number }>({
     year: new Date().getFullYear(),
@@ -56,7 +56,7 @@ export const MainCalendar: React.FC = () => {
     const fetch = async () => {
       try {
         const { startDate, endDate } = getMonthDateRange(year, month);
-        const entries = await getCalendarJournalEntries(startDate, endDate);
+        const entries = await fetchCalendarJournalEntries(startDate, endDate);
         setMonthlyJournalEntries(entries);
       } catch (error) {
         console.error('Error fetching monthly calendar journal entries:', error);
@@ -65,7 +65,7 @@ export const MainCalendar: React.FC = () => {
     };
 
     fetch();
-  }, [currentMonth, getCalendarJournalEntries, getMonthDateRange]);
+  }, [currentMonth, getMonthDateRange]);
 
 // --- useCallbackで関数を安定化 ---
 const getEntriesForDate = useCallback(
@@ -196,7 +196,7 @@ useEffect(() => {
         
         // カレンダーを再描画するため、月間データを再取得
         const { startDate, endDate } = getMonthDateRange(currentMonth.year, currentMonth.month);
-        const entries = await getCalendarJournalEntries(startDate, endDate);
+        const entries = await fetchCalendarJournalEntries(startDate, endDate);
         setMonthlyJournalEntries(entries);
         
         setEditingEntry(null);

--- a/desktop/src/components/journal/JournalAccountManager.tsx
+++ b/desktop/src/components/journal/JournalAccountManager.tsx
@@ -6,7 +6,10 @@ import { useScrollToTop } from '../../hooks/useScrollToTop';
 
 export const JournalAccountManager: React.FC = () => {
   const scrollToTop = useScrollToTop('journal-account-manager');
-  const { journalAccounts, addJournalAccount, updateJournalAccount, getJournalAccounts } = useFinancialStore();
+  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
+  const addJournalAccount = useFinancialStore((s) => s.addJournalAccount);
+  const updateJournalAccount = useFinancialStore((s) => s.updateJournalAccount);
+  const fetchJournalAccounts = useFinancialStore((s) => s.fetchJournalAccounts);
   
   const [isEditing, setIsEditing] = useState(false);
   const [currentAccount, setCurrentAccount] = useState<Omit<JournalAccount, 'id'> | JournalAccount>({
@@ -39,7 +42,7 @@ export const JournalAccountManager: React.FC = () => {
         await addJournalAccount(currentAccount as Omit<JournalAccount, 'id'>);
       }
       // 勘定科目が変わったのでキャッシュをリフレッシュ
-      await getJournalAccounts();
+      await fetchJournalAccounts();
       resetForm();
     } catch (error) {
       console.error('Journal account save failed:', error);

--- a/desktop/src/components/journal/JournalDashboard.tsx
+++ b/desktop/src/components/journal/JournalDashboard.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { useFinancialStore, useAuthStore, BalanceSheetView, ProfitLossView, formatDateLocal, filterSummaryIncludedRows } from '@asset-simulator/shared';
+import { useFinancialStore, useAuthStore, fetchBalanceSheet, fetchProfitLoss, BalanceSheetView, ProfitLossView, formatDateLocal, filterSummaryIncludedRows } from '@asset-simulator/shared';
 import { DateRangePicker, DateRange, DateRangeSettings } from '../common/DateRangePicker';
 
 export const JournalDashboard: React.FC = () => {
-  const { getBalanceSheetView, getProfitLossStatementView, journalAccounts } = useFinancialStore();
+  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
   const { userId } = useAuthStore();
 
   const getInitialRange = (): DateRange => {
@@ -126,8 +126,8 @@ const getStoredDateRange = (): DateRange => {
       setIsLoading(true);
       try {
         const [bsRows, plRows] = await Promise.all([
-          getBalanceSheetView(bsAsOfDate),
-          getProfitLossStatementView(dateRange.startDate, dateRange.endDate)
+          fetchBalanceSheet(bsAsOfDate),
+          fetchProfitLoss(dateRange.startDate, dateRange.endDate)
         ]);
         setBsData(bsRows);
         setPlData(plRows);
@@ -138,7 +138,7 @@ const getStoredDateRange = (): DateRange => {
       }
     };
     fetchData();
-  }, [getBalanceSheetView, getProfitLossStatementView, bsAsOfDate, dateRange]);
+  }, [bsAsOfDate, dateRange]);
 
   const groupByCategory = (rows: BalanceSheetView[] | ProfitLossView[]): Record<string, number> => {
     const grouped: Record<string, number> = {};

--- a/desktop/src/components/journal/JournalEntryForm.tsx
+++ b/desktop/src/components/journal/JournalEntryForm.tsx
@@ -1,11 +1,12 @@
 // src/components/JournalEntryForm.tsx
 
 import React, { useEffect, useState } from 'react';
-import { useFinancialStore, todayLocalString } from '@asset-simulator/shared';
+import { useFinancialStore, fetchFrequentEntrySets, todayLocalString } from '@asset-simulator/shared';
 import type { FrequentEntrySet } from '@asset-simulator/shared';
 
 export const JournalEntryForm: React.FC = () => {
-  const { journalAccounts, addJournalEntry, getFrequentJournalEntrySets } = useFinancialStore();
+  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
+  const addJournalEntry = useFinancialStore((s) => s.addJournalEntry);
 
   const [visible, setVisible] = useState(true);
 
@@ -19,13 +20,13 @@ export const JournalEntryForm: React.FC = () => {
   // 直近の仕訳から「よく使う取引入力値セット」を取得してサジェストする
   useEffect(() => {
     let isMounted = true;
-    getFrequentJournalEntrySets().then((sets) => {
+    fetchFrequentEntrySets().then((sets) => {
       if (isMounted) setSuggestions(sets);
     });
     return () => {
       isMounted = false;
     };
-  }, [getFrequentJournalEntrySets]);
+  }, []);
 
   const accountName = (id: string) =>
     journalAccounts.find((acc) => acc.id === id)?.name ?? '不明';

--- a/desktop/src/components/journal/RecurringTransactionManager.tsx
+++ b/desktop/src/components/journal/RecurringTransactionManager.tsx
@@ -3,25 +3,23 @@ import { useFinancialStore, RecurringTransaction, getNextExecutionDate, todayLoc
 import { RecurringTransactionFormModal } from './RecurringTransactionFormModal';
 
 export const RecurringTransactionManager: React.FC = () => {
-  const { 
-    journalAccounts, 
-    addRegularJournalEntry,
-    updateRegularJournalEntry,
-    deleteRegularJournalEntry,
-    executeRegularJournalEntry,
-    executeDueRegularJournalEntries
-  } = useFinancialStore();
-  
-  const { regularJournalEntries, getRegularJournalEntries } = useFinancialStore();
+  const journalAccounts = useFinancialStore((s) => s.journalAccounts);
+  const addRegularJournalEntry = useFinancialStore((s) => s.addRegularJournalEntry);
+  const updateRegularJournalEntry = useFinancialStore((s) => s.updateRegularJournalEntry);
+  const deleteRegularJournalEntry = useFinancialStore((s) => s.deleteRegularJournalEntry);
+  const executeRegularJournalEntry = useFinancialStore((s) => s.executeRegularJournalEntry);
+  const executeDueRegularJournalEntries = useFinancialStore((s) => s.executeDueRegularJournalEntries);
+  const regularJournalEntries = useFinancialStore((s) => s.regularJournalEntries);
+  const fetchRegularJournalEntries = useFinancialStore((s) => s.fetchRegularJournalEntries);
 
   // 初回ロード時に定期取引データを取得
   const hasFetchedRef = React.useRef(false);
   useEffect(() => {
     if (!hasFetchedRef.current) {
-      getRegularJournalEntries();
+      fetchRegularJournalEntries();
       hasFetchedRef.current = true;
     }
-  }, [getRegularJournalEntries]);
+  }, [fetchRegularJournalEntries]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Partial<RecurringTransaction> | null>(null);

--- a/docs/api/specification.md
+++ b/docs/api/specification.md
@@ -11,6 +11,7 @@
 - [VIEW](#view)
 - [RPC 関数一覧](#rpc-関数一覧)
 - [ストアアクション一覧](#ストアアクション一覧)
+- [純粋クエリ一覧（packages/shared/src/queries/）](#純粋クエリ一覧packagessharedsrcqueries)
 - [定期取引の実行仕様](#定期取引の実行仕様)
 
 ---
@@ -49,15 +50,15 @@
 
 | テーブル | 操作 | 呼び出し元アクション | フィルタ | ソート順 |
 |---------|------|---------------------|---------|---------|
-| `journal_accounts` | select | `getJournalAccounts` | `user_id = :userId` | `category` 昇順 → `name` 昇順 |
+| `journal_accounts` | select | `fetchJournalAccounts`（financialStore アクション） | `user_id = :userId` | `category` 昇順 → `name` 昇順 |
 | `journal_accounts` | insert | `addJournalAccount` | — | — |
 | `journal_accounts` | update | `updateJournalAccount` | `id`, `user_id` | — |
 | `journal_accounts` | delete | `deleteJournalAccount` | `id`, `user_id` | — |
-| `journal_entries` | select | `getFrequentJournalEntrySets`（取引入力サジェスト用の直近仕訳取得） | `user_id = :userId` | `date` 降順（直近200件に limit） |
+| `journal_entries` | select | `fetchFrequentEntrySets`（`packages/shared/src/queries/journalEntries.ts` の純粋クエリ。取引入力サジェスト用の直近仕訳取得） | `user_id = :userId` | `date` 降順（直近200件に limit） |
 | `journal_entries` | insert | `insertRecurringExecution`（定期取引実行時の内部ヘルパー） | — | — |
 | `journal_entries` | update | `updateJournalEntry` | `id`, `user_id` | — |
 | `journal_entries` | delete | `deleteJournalEntry` | `id`, `user_id` | — |
-| `regular_journal_entries` | select | `getRegularJournalEntries`, `executeRegularJournalEntry`（単票取得）, `executeDueRegularJournalEntries`（全件取得） | `user_id = :userId`（単票取得は `id` も指定） | `start_date` 降順（一覧取得時） |
+| `regular_journal_entries` | select | `fetchRegularJournalEntries`（financialStore アクション）, `executeRegularJournalEntry`（単票取得）, `executeDueRegularJournalEntries`（全件取得） | `user_id = :userId`（単票取得は `id` も指定） | `start_date` 降順（一覧取得時） |
 | `regular_journal_entries` | insert | `addRegularJournalEntry` | — | — |
 | `regular_journal_entries` | update | `updateRegularJournalEntry`, `insertRecurringExecution`（`last_executed_date` 更新） | `id`, `user_id` | — |
 | `regular_journal_entries` | delete | `deleteRegularJournalEntry` | `id`, `user_id` | — |
@@ -65,7 +66,7 @@
 | `schedule_events` | insert | `addEvent` | — | — |
 | `schedule_events` | update | `updateEvent` | `event_id`, `user_id` | — |
 | `schedule_events` | delete | `deleteEvent` | `event_id`, `user_id` | — |
-| `goals` | select | `getGoals` | `user_id = :userId` | — |
+| `goals` | select | `fetchGoals`（financialStore アクション） | `user_id = :userId` | — |
 | `goals` | insert | `addGoal` | — | — |
 | `goals` | update | `updateGoal` | `id`, `user_id` | — |
 | `goals` | delete | `deleteGoal` | `id`, `user_id` | — |
@@ -82,7 +83,7 @@
 
 | 呼び出し元 | フィルタ | ソート順 |
 |-----------|---------|---------|
-| `getCalendarJournalEntries(startDate, endDate)` | `user_id`, `date >= startDate`, `date <= endDate` | `date` 降順 |
+| `fetchCalendarJournalEntries(startDate, endDate)`（`packages/shared/src/queries/journalEntries.ts` の純粋クエリ） | `user_id`, `date >= startDate`, `date <= endDate` | `date` 降順 |
 
 対応する型は `packages/shared/src/types/common.ts` の `CalendarJournalEntry`（`debitAccountName`, `debitAccountCategory`, `creditAccountName`, `creditAccountCategory` を含む）。
 
@@ -115,7 +116,7 @@
 
 - **引数**: `p_user_id: string`, `p_end_date: string`（`YYYY-MM-DD`。省略時は `todayLocalString()`）
 - **戻り値行**: `user_id`, `account_id`, `category`, `name`, `sum_amount`（フロントでは `toCamelCase` 後に型 `BalanceSheetView` として扱う）
-- **呼び出し元**: `financialStore.getBalanceSheetView`
+- **呼び出し元**: `fetchBalanceSheet`（`packages/shared/src/queries/reports.ts` の純粋クエリ。ストアアクションではない）
 - **使用例**:
   ```ts
   const { data } = await supabase.rpc('fn_balance_sheet', {
@@ -123,7 +124,7 @@
     p_user_id: userId,
   });
   ```
-- **サマリー除外（変動資産等）**: RPC の戻り値自体は `journal_accounts.include_in_summary` によるフィルタを行わない。`include_in_summary = false` の勘定科目をダッシュボードの合計・明細から除くのはフロントエンドの責務で、`filterSummaryIncludedRows`（`@asset-simulator/shared`）を `getBalanceSheetView` の結果に適用する
+- **サマリー除外（変動資産等）**: RPC の戻り値自体は `journal_accounts.include_in_summary` によるフィルタを行わない。`include_in_summary = false` の勘定科目をダッシュボードの合計・明細から除くのはフロントエンドの責務で、`filterSummaryIncludedRows`（`@asset-simulator/shared`）を `fetchBalanceSheet` の結果に適用する
 
 ### `fn_profit_loss(p_user_id, p_start_date, p_end_date)`
 
@@ -131,7 +132,7 @@
 
 - **引数**: `p_user_id: string`, `p_start_date: string`（省略時は当月1日）, `p_end_date: string`（省略時は本日）
 - **戻り値行**: `user_id`, `account_id`, `category`, `name`, `sum_amount`（型 `ProfitLossView`）
-- **呼び出し元**: `financialStore.getProfitLossStatementView`
+- **呼び出し元**: `fetchProfitLoss`（`packages/shared/src/queries/reports.ts` の純粋クエリ。ストアアクションではない）
 - **使用例**:
   ```ts
   const { data } = await supabase.rpc('fn_profit_loss', {
@@ -149,26 +150,25 @@
 
 ### financialStore（`packages/shared/src/stores/financialStore.ts`）
 
+state に書き込む「取得系」アクションは `fetchXxx` 名で統一している（`journalEntries` state は未使用のため廃止済み。カレンダー取得・サジェスト取得・BS/PL 取得は state を持たないため、下記[純粋クエリ一覧](#純粋クエリ一覧packagessharedsrcqueries)を参照）。
+
 | アクション | シグネチャ | 処理概要 | エラー時挙動 |
 |-----------|-----------|---------|-------------|
-| `getJournalAccounts` | `() => Promise<JournalAccount[]>` | `journal_accounts` を取得し state に反映 | `console.error` して現在の state を返す |
-| `getCalendarJournalEntries` | `(startDate, endDate) => Promise<CalendarJournalEntry[]>` | VIEW `v_journal_entries_for_calendar` を期間指定で取得（state には保存しない） | `console.error` して `[]` を返す |
-| `getFrequentJournalEntrySets` | `(limit?) => Promise<FrequentEntrySet[]>` | `journal_entries` の直近200件から（摘要・借方・貸方・金額）の組み合わせを `aggregateFrequentEntrySets`（`utils/frequentEntries.ts`）で集計し、出現回数順に上位 `limit` 件（デフォルト5）を返す（state には保存しない） | `console.error` して `[]` を返す |
-| `getRegularJournalEntries` | `() => Promise<RecurringTransaction[]>` | `regular_journal_entries` を取得し state に反映 | `console.error` して現在の state を返す |
-| `getBalanceSheetView` | `(asOfDate?) => Promise<BalanceSheetView[]>` | RPC `fn_balance_sheet` 呼び出し | `console.error` して `[]` |
-| `getProfitLossStatementView` | `(startDate?, endDate?) => Promise<ProfitLossView[]>` | RPC `fn_profit_loss` 呼び出し | `console.error` して `[]` |
+| `fetchJournalAccounts` | `() => Promise<JournalAccount[]>` | `journal_accounts` を取得し state に反映 | `console.error` して現在の state を返す |
+| `fetchRegularJournalEntries` | `() => Promise<RecurringTransaction[]>` | `regular_journal_entries` を取得し state に反映 | `console.error` して現在の state を返す |
 | `addJournalAccount` | `(account: Omit<JournalAccount,'id'>) => Promise<void>` | `jacc_` ID 発行 → insert（`name`/`category`/`include_in_summary`）→ state に追加 | `console.error`（呼び出し元には伝播しない） |
-| `addJournalEntry` | `(entry: Omit<JournalEntry,'id'>) => Promise<void>` | `je_` ID 発行 → RPC `create_journal_entry` → state に追加 | 同上 |
+| `addJournalEntry` | `(entry: Omit<JournalEntry,'id'>) => Promise<void>` | `je_` ID 発行 → RPC `create_journal_entry` | 同上 |
 | `addRegularJournalEntry` | `(entry: Omit<RecurringTransaction,'id'>) => Promise<void>` | `reg_` ID 発行 → `toSnakeCase` → insert → state に追加 | 同上 |
 | `updateJournalAccount` | `(account: JournalAccount) => Promise<void>` | `name`/`category`/`include_in_summary` を update → state を置換 | 同上 |
-| `updateJournalEntry` | `(entry: JournalEntry) => Promise<void>` | 全フィールド update（`amount` は `parseFloat`） | 同上 |
+| `updateJournalEntry` | `(entry: JournalEntry) => Promise<void>` | 全フィールド update（`amount` は `parseFloat`）。`journalEntries` state は持たないため state 更新なし | 同上 |
 | `updateRegularJournalEntry` | `(entry: RecurringTransaction) => Promise<void>` | `toSnakeCase(entry)` を丸ごと update | 同上 |
-| `deleteJournalAccount` / `deleteJournalEntry` / `deleteRegularJournalEntry` | `(entity) => Promise<void>` | delete → state から filter で除去 | 同上 |
-| `getGoals` | `() => Promise<Goal[]>` | `goals` を取得し state に反映 | `console.error` して現在の state を返す |
+| `deleteJournalAccount` / `deleteRegularJournalEntry` | `(entity) => Promise<void>` | delete → state から filter で除去 | 同上 |
+| `deleteJournalEntry` | `(entry: JournalEntry) => Promise<void>` | delete。`journalEntries` state は持たないため state 更新なし | 同上 |
+| `fetchGoals` | `() => Promise<Goal[]>` | `goals` を取得し state に反映 | `console.error` して現在の state を返す |
 | `addGoal` | `(goal: Omit<Goal,'id'>) => Promise<void>` | `goal_` ID 発行 → `toSnakeCase` → insert → state に追加 | `console.error`（呼び出し元には伝播しない） |
 | `updateGoal` | `(goal: Goal) => Promise<void>` | `amount` を update → state を置換 | 同上 |
 | `deleteGoal` | `(goal: Goal) => Promise<void>` | delete → state から filter で除去 | 同上 |
-| `executeRegularJournalEntry` | `(entry: RecurringTransaction) => Promise<void>` | 定期取引を1件手動実行（下記参照）。実行後に `getJournalAccounts` / `getRegularJournalEntries` を呼び直す | `console.error`（同日重複実行は内部で `throw` するが catch されて握りつぶされる） |
+| `executeRegularJournalEntry` | `(entry: RecurringTransaction) => Promise<void>` | 定期取引を1件手動実行（下記参照）。実行後に `fetchJournalAccounts` / `fetchRegularJournalEntries` を呼び直す | `console.error`（同日重複実行は内部で `throw` するが catch されて握りつぶされる） |
 | `executeDueRegularJournalEntries` | `() => Promise<{executed:number, details:any[]}>` | 全定期取引を走査し当日実行対象を一括実行 | エラーを再 throw する（呼び出し元で catch が必要） |
 
 ### eventsStore（`packages/shared/src/stores/eventsStore.ts`）
@@ -189,6 +189,26 @@
 | `signOut` | `() => Promise<void>` | `supabase.auth.signOut()` の上で `session`/`userId` を `null` にリセット |
 
 `useAuthStore` は `client: SupabaseClient` もそのまま公開しており、`Auth`（`@supabase/auth-ui-react`）コンポーネントに直接渡している（desktop の `App.tsx`、mobile の `LoginScreen.tsx`）。
+
+---
+
+## 純粋クエリ一覧（`packages/shared/src/queries/`）
+
+`set()` を呼ばない「取得のみ・state を持たない」クエリはストアのアクションではなく、モジュールスコープの素の async 関数として `packages/shared/src/queries/` に置く。呼び出し側は Zustand フックを経由せず `@asset-simulator/shared` から直接 import して呼ぶ（例: `import { fetchBalanceSheet } from '@asset-simulator/shared'`）。内部実装（引数・フィルタ・エラーハンドリング）はストア時代から変更していない。
+
+### journalEntries.ts
+
+| 関数 | シグネチャ | 処理概要 | エラー時挙動 |
+|-----|-----------|---------|-------------|
+| `fetchCalendarJournalEntries` | `(startDate, endDate) => Promise<CalendarJournalEntry[]>` | VIEW `v_journal_entries_for_calendar` を期間指定で取得 | `console.error` して `[]` を返す |
+| `fetchFrequentEntrySets` | `(limit?) => Promise<FrequentEntrySet[]>` | `journal_entries` の直近200件（`FREQUENT_ENTRY_LOOKBACK_COUNT`）から（摘要・借方・貸方・金額）の組み合わせを `aggregateFrequentEntrySets`（`utils/frequentEntries.ts`）で集計し、出現回数順に上位 `limit` 件（デフォルト5）を返す | `console.error` して `[]` を返す |
+
+### reports.ts
+
+| 関数 | シグネチャ | 処理概要 | エラー時挙動 |
+|-----|-----------|---------|-------------|
+| `fetchBalanceSheet` | `(asOfDate?) => Promise<BalanceSheetView[]>` | RPC `fn_balance_sheet` 呼び出し | `console.error` して `[]` |
+| `fetchProfitLoss` | `(startDate?, endDate?) => Promise<ProfitLossView[]>` | RPC `fn_profit_loss` 呼び出し | `console.error` して `[]` |
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -46,12 +46,13 @@ asset-simulator/
 │   │       NumericInput, PanelButton, PeriodSelector, SelectInput, TextInput
 │   └── src/               # Storybook エントリー用スキャフォールド（Vite デフォルトテンプレート、アプリ本体ではない）
 ├── packages/
-│   └── shared/           # 共有型・ユーティリティ・Zustand ストア
+│   └── shared/           # 共有型・ユーティリティ・Zustand ストア・純粋クエリ
 │       └── src/
 │           ├── types/    # 型定義のみ（common.ts）
 │           ├── utils/    # ユーティリティ関数（caseConvert / dateUtils / period / recurrence）
 │           │   └── __tests__/  # Jest ユニットテスト
-│           └── stores/   # Zustand ストア（financialStore / eventsStore / authStore）
+│           ├── stores/   # Zustand ストア（financialStore / eventsStore / authStore）
+│           └── queries/  # state を持たない読み取り専用クエリ（journalEntries.ts / reports.ts）
 └── docs/                 # 設計ドキュメント（本ディレクトリ）
 ```
 
@@ -83,7 +84,16 @@ alias は `client/vite.config.ts` で定義:
 | eventsStore | `eventsStore.ts` | スケジュールイベントの CRUD |
 | authStore | `authStore.ts` | Supabase クライアント・セッション・`userId` |
 
-**リフレッシュルール**: ミューテーション後は変更したリソースのアクション（`getJournalAccounts()` 等）だけを個別に呼ぶ。広範囲な「全データ再取得」関数は持たない。`financialStore` は `useAuthStore.subscribe` でログアウトを検知し、`userId` が空になったらキャッシュをクリアする。
+**リフレッシュルール**: ミューテーション後は変更したリソースのアクション（`fetchJournalAccounts()` 等）だけを個別に呼ぶ。広範囲な「全データ再取得」関数は持たない。`financialStore` は `useAuthStore.subscribe` でログアウトを検知し、`userId` が空になったらキャッシュをクリアする。
+
+## shared/queries
+
+`state` を持たない「取得のみ」の純粋クエリは `packages/shared/src/queries/` に置き、ストアのアクションとは別のモジュールスコープの async 関数として公開する（呼び出し側は `@asset-simulator/shared` から直接 import する）。
+
+| ファイル | 内容 |
+|---------|------|
+| `journalEntries.ts` | `fetchCalendarJournalEntries`（カレンダー用VIEW取得）、`fetchFrequentEntrySets`（よく使う入力サジェスト集計）、`FREQUENT_ENTRY_LOOKBACK_COUNT` |
+| `reports.ts` | `fetchBalanceSheet` / `fetchProfitLoss`（BS/PL RPC 呼び出し） |
 
 ## shared/utils
 

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -23,7 +23,7 @@ ER 図: [er_diagram.puml](er_diagram.puml)
 | created_at | timestamp | — |
 | updated_at | timestamp | — |
 
-ソート順（`getJournalAccounts`）: `category` 昇順 → `name` 昇順。
+ソート順（`fetchJournalAccounts`）: `category` 昇順 → `name` 昇順。
 
 `include_in_summary = false` の勘定科目は `fn_balance_sheet` の戻り値自体には引き続き含まれる（DB 側では絞り込まない）。除外はフロントエンド側で `filterSummaryIncludedRows`（`packages/shared/src/utils/balanceSheet.ts`）を用いて行う（desktop の `JournalDashboard`、mobile の `App`/`BalanceSheetCard` で共通利用）。
 
@@ -74,7 +74,7 @@ ER 図: [er_diagram.puml](er_diagram.puml)
 | created_at | timestamp | — |
 | updated_at | timestamp | — |
 
-ソート順（`getRegularJournalEntries`）: `start_date` 降順。
+ソート順（`fetchRegularJournalEntries`）: `start_date` 降順。
 
 > 旧版との差分: `holiday_div_of_month` は boolean ではなく文字列 enum。`public_holiday_ex_flg_of_week` のスペル修正（旧: `public_holiiday_ex_flg_week`。コード上の camelCase `publicHolidayExFlgOfWeek` に対応する snake_case）。`thu_flg_of_week` のスペル修正（旧: `thr_flg_of_week`）。`last_executed_date` を追加。`frequency` に `free` を追加。
 

--- a/docs/test/scenarios.md
+++ b/docs/test/scenarios.md
@@ -76,7 +76,7 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 
 | # | Given | When | Then |
 |---|-------|------|------|
-| 1 | 勘定科目未登録 | (desktop) 名称+カテゴリを入力し追加 | 一覧に追加され、`getJournalAccounts()` で最新化される |
+| 1 | 勘定科目未登録 | (desktop) 名称+カテゴリを入力し追加 | 一覧に追加され、`fetchJournalAccounts()` で最新化される |
 | 2 | 既存の通常勘定科目 | (desktop) 編集ボタンから名称/カテゴリを変更して保存 | 一覧が更新される |
 | 3 | `acc_`/`card_` プレフィックスの勘定科目を編集開始 | — | カテゴリ `<select>` が `disabled` になる（`isSystemAccount` 判定） |
 | 4 | 勘定科目未登録 | (mobile) 名称+カテゴリを入力し「勘定科目を追加」 | 一覧に反映される |
@@ -99,7 +99,7 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 
 | # | Given | When | Then |
 |---|-------|------|------|
-| 1 | カレンダー表示中 | 月を前後に移動する | `getCalendarJournalEntries(startDate, endDate)` が新しい月の範囲で再取得される（同じ月に戻っても再フェッチしない: `lastFetchRef`） |
+| 1 | カレンダー表示中 | 月を前後に移動する | `fetchCalendarJournalEntries(startDate, endDate)` が新しい月の範囲で再取得される（同じ月に戻っても再フェッチしない: `lastFetchRef`） |
 | 2 | 仕訳・イベントがある日 | 日付を選択 | 選択日の仕訳一覧・イベント一覧・費用/収益サマリーが表示される |
 | 3 | (desktop) 借方/貸方フィルタを設定 | 日付選択・タイル表示を確認 | フィルタ条件に合う仕訳のみが集計・表示される |
 | 4 | (mobile) 日付をダブルタップ | — | 取引入力ダイアログ（`TransactionEntryCard`）がその日付で開く |

--- a/docs/ui/specification.md
+++ b/docs/ui/specification.md
@@ -62,17 +62,17 @@ App (desktop/src/App.tsx)
 
 ### 2.3 各コンポーネントの責務
 
-| コンポーネント | ファイル | 責務 | 使用するストアアクション |
+| コンポーネント | ファイル | 責務 | 使用するストアアクション/クエリ |
 |---------------|---------|------|------------------------|
-| `App` | `src/App.tsx` | 認証状態監視・タブ切り替え・初回データ取得 | `getJournalAccounts`, `getRegularJournalEntries`, `fetchEvents` |
-| `JournalEntryForm` | `components/journal/JournalEntryForm.tsx` | 仕訳の新規登録フォーム。カードヘッダークリックで折りたたみ。「よく使う入力」サジェスト（直近仕訳の頻出セット）をタップするとフォームに反映 | `addJournalEntry`, `getFrequentJournalEntrySets`（`journalAccounts` を購読） |
-| `MainCalendar` | `components/MainCalendar.tsx` | `react-calendar` による月間カレンダー。日別の仕訳・イベント表示、借方/貸方フィルタ、費用/収益サマリー | `getCalendarJournalEntries`（月が変わるたびに再取得）, `updateJournalEntry`（編集モーダル保存時） |
+| `App` | `src/App.tsx` | 認証状態監視・タブ切り替え・初回データ取得 | `fetchJournalAccounts`, `fetchRegularJournalEntries`, `fetchEvents` |
+| `JournalEntryForm` | `components/journal/JournalEntryForm.tsx` | 仕訳の新規登録フォーム。カードヘッダークリックで折りたたみ。「よく使う入力」サジェスト（直近仕訳の頻出セット）をタップするとフォームに反映 | `addJournalEntry`（アクション）, `fetchFrequentEntrySets`（`@asset-simulator/shared` の純粋クエリ、直接 import）（`journalAccounts` を購読） |
+| `MainCalendar` | `components/MainCalendar.tsx` | `react-calendar` による月間カレンダー。日別の仕訳・イベント表示、借方/貸方フィルタ、費用/収益サマリー | `fetchCalendarJournalEntries`（純粋クエリ、直接 import。月が変わるたびに再取得）, `updateJournalEntry`（アクション、編集モーダル保存時） |
 | `JournalEntriesModal` | `components/journal/JournalEntriesModal.tsx` | `MainCalendar` から開く仕訳編集モーダル（フィールド編集のみ、保存は呼び出し元） | なし（props 経由の callback） |
-| `JournalDashboard` | `components/journal/JournalDashboard.tsx` | BS/PL の表示。期間・基準日は `localStorage` に `userId` ごとに永続化 | `getBalanceSheetView`, `getProfitLossStatementView` |
+| `JournalDashboard` | `components/journal/JournalDashboard.tsx` | BS/PL の表示。期間・基準日は `localStorage` に `userId` ごとに永続化 | `fetchBalanceSheet`, `fetchProfitLoss`（いずれも純粋クエリ、直接 import） |
 | `DateRangePicker` | `components/common/DateRangePicker.tsx` | 週/月/年/カスタムのプリセット選択 UI。shared の `computePeriodRange`/`shiftPeriodRange` を呼ぶ | ストア未使用（shared/utils のみ） |
-| `RecurringTransactionManager` | `components/journal/RecurringTransactionManager.tsx` | 定期取引の一覧・フィルタ・ソート・実行。マウント時+10分間隔で期限到来分を自動実行 | `getRegularJournalEntries`, `addRegularJournalEntry`, `updateRegularJournalEntry`, `deleteRegularJournalEntry`, `executeRegularJournalEntry`, `executeDueRegularJournalEntries` |
+| `RecurringTransactionManager` | `components/journal/RecurringTransactionManager.tsx` | 定期取引の一覧・フィルタ・ソート・実行。マウント時+10分間隔で期限到来分を自動実行 | `fetchRegularJournalEntries`, `addRegularJournalEntry`, `updateRegularJournalEntry`, `deleteRegularJournalEntry`, `executeRegularJournalEntry`, `executeDueRegularJournalEntries` |
 | `RecurringTransactionFormModal` | `components/journal/RecurringTransactionFormModal.tsx` | 定期取引の新規作成・編集用モーダル（頻度に応じて入力項目が切り替わる） | なし（`RecurringTransactionManager` から `formData`/`onChange`/`onSave` を受け取る） |
-| `JournalAccountManager` | `components/journal/JournalAccountManager.tsx` | 勘定科目の追加・編集一覧。`isSystemAccount()`（`acc_`/`card_` プレフィックス）はカテゴリ編集を禁止 | `addJournalAccount`, `updateJournalAccount`, `getJournalAccounts` |
+| `JournalAccountManager` | `components/journal/JournalAccountManager.tsx` | 勘定科目の追加・編集一覧。`isSystemAccount()`（`acc_`/`card_` プレフィックス）はカテゴリ編集を禁止 | `addJournalAccount`, `updateJournalAccount`, `fetchJournalAccounts` |
 | `EventScheduleForm` | `components/event/EventScheduleForm.tsx` | イベントの新規登録・編集フォーム（`editingEvent` props があれば編集モード） | `addEvent`（新規時のみ。編集時は親の `onSave` 経由で `updateEvent`） |
 | `EventScheduleManager` | `components/event/EventScheduleManager.tsx` | イベント一覧（すべて/今後/過去フィルタ）、編集・削除 | `updateEvent`, `deleteEvent`（`events` を購読） |
 
@@ -100,17 +100,17 @@ App (desktop/src/App.tsx)
 
 ### 3.2 各カードの責務
 
-| コンポーネント | ファイル | 責務 | 使用するストアアクション |
+| コンポーネント | ファイル | 責務 | 使用するストアアクション/クエリ |
 |---------------|---------|------|------------------------|
-| `App` | `mobile/app/src/App.tsx` | 認証監視・タブ切り替え（`CalendarCard` は常時マウントし `display` で表示のみ切り替えることで、タブ移動後もフィルタ・表示月・選択日を保持）・PL/BS 期間の一括管理・支出目標用の月次期間（`goalMonthRange`）の導出（月単位プリセット選択中は表示中の期間、それ以外は期間設定に基づく現在の月次期間）・取引入力/編集ダイアログの開閉 | `getJournalAccounts`, `getRegularJournalEntries`, `fetchEvents`, `getProfitLossStatementView`, `getBalanceSheetView` |
+| `App` | `mobile/app/src/App.tsx` | 認証監視・タブ切り替え（`CalendarCard` は常時マウントし `display` で表示のみ切り替えることで、タブ移動後もフィルタ・表示月・選択日を保持）・PL/BS 期間の一括管理・支出目標用の月次期間（`goalMonthRange`）の導出（月単位プリセット選択中は表示中の期間、それ以外は期間設定に基づく現在の月次期間）・取引入力/編集ダイアログの開閉 | `fetchJournalAccounts`, `fetchRegularJournalEntries`, `fetchEvents`（アクション）, `fetchProfitLoss`, `fetchBalanceSheet`（純粋クエリ、直接 import） |
 | `LoginScreen` | `LoginScreen.tsx` | 未ログイン時のログイン画面（Supabase Auth UI） | なし（`useAuthStore` の `client` のみ） |
-| `CalendarCard` | `CalendarCard.tsx` | 月表示のカレンダー。日付タップで選択、ダブルタップで取引入力ダイアログを開く。選択日の取引一覧・編集/削除。勘定科目セレクト（初期値「すべて」）で取引を絞り込み（借方・貸方のどちらかが一致、日付セルのドット表示にも反映） | `getCalendarJournalEntries`, `deleteJournalEntry`（`journalAccounts` を購読） |
-| `TransactionEntryCard` | `TransactionEntryCard.tsx` | 取引の新規登録／編集（`entry` props の有無でモード切替）。新規登録モードでは「よく使う入力」サジェスト（直近仕訳の頻出セット）を登録ボタンの下に表示し、タップで摘要・借方・貸方・金額をフォームに反映 | `addJournalEntry`, `updateJournalEntry`, `getJournalAccounts`（残高反映のため再取得）, `getFrequentJournalEntrySets`（新規モードのみ） |
+| `CalendarCard` | `CalendarCard.tsx` | 月表示のカレンダー。日付タップで選択、ダブルタップで取引入力ダイアログを開く。選択日の取引一覧・編集/削除。勘定科目セレクト（初期値「すべて」）で取引を絞り込み（借方・貸方のどちらかが一致、日付セルのドット表示にも反映） | `fetchCalendarJournalEntries`（純粋クエリ、直接 import）, `deleteJournalEntry`（アクション）（`journalAccounts` を購読） |
+| `TransactionEntryCard` | `TransactionEntryCard.tsx` | 取引の新規登録／編集（`entry` props の有無でモード切替）。新規登録モードでは「よく使う入力」サジェスト（直近仕訳の頻出セット）を登録ボタンの下に表示し、タップで摘要・借方・貸方・金額をフォームに反映 | `addJournalEntry`, `updateJournalEntry`, `fetchJournalAccounts`（アクション、残高反映のため再取得）, `fetchFrequentEntrySets`（純粋クエリ、直接 import、新規モードのみ） |
 | `ProfitLossStatementCard` | `ProfitLossStatementCard.tsx` | 収益・費用の明細サマリーリスト（`PeriodSelector` 内包） | なし（`rows` は `App` から props で受け取る） |
 | `BalanceSheetCard` | `BalanceSheetCard.tsx` | 資産・負債・純資産の明細サマリーリスト（基準日プリセット: 今日/今月末/先月末） | なし（`rows` は props） |
 | `RecurringTransactionCard` | `RecurringTransactionCard.tsx` | 定期取引の一覧・追加（ダイアログ）・実行・削除・期限到来分一括実行 | `addRegularJournalEntry`, `deleteRegularJournalEntry`, `executeRegularJournalEntry`, `executeDueRegularJournalEntries` |
 | `AccountMasterCard` | `AccountMasterCard.tsx` | 勘定科目の追加・一覧・**削除**（desktop の勘定科目管理は編集のみで削除なし） | `addJournalAccount`, `deleteJournalAccount` |
-| `GoalCard` | `GoalCard.tsx` | 費用科目ごと・期間（日次/月次）ごとの支出目標の設定（ダイアログ、同一科目・期間は金額を上書き）・一覧・進捗表示（対象期間・達成率%・残額/超過額・実績支出との比較バー）・削除。月次の対象期間は props の `monthRange`（ダッシュボードの月次指定期間と同期、`App` が導出）、日次は当日。`refreshSignal` の変化で実績を再取得。`transaction` タブと `pl-bs` タブの両方から利用可能 | `getGoals`, `addGoal`, `updateGoal`, `deleteGoal`, `getProfitLossStatementView`（実績取得） |
+| `GoalCard` | `GoalCard.tsx` | 費用科目ごと・期間（日次/月次）ごとの支出目標の設定（ダイアログ、同一科目・期間は金額を上書き）・一覧・進捗表示（対象期間・達成率%・残額/超過額・実績支出との比較バー）・削除。月次の対象期間は props の `monthRange`（ダッシュボードの月次指定期間と同期、`App` が導出）、日次は当日。`refreshSignal` の変化で実績を再取得。`transaction` タブと `pl-bs` タブの両方から利用可能 | `fetchGoals`, `addGoal`, `updateGoal`, `deleteGoal`（アクション）, `fetchProfitLoss`（純粋クエリ、直接 import、実績取得） |
 
 モバイル版には勘定科目の「編集」機能はない（追加・削除のみ）。desktop 版には「削除」機能がない（追加・編集のみ）。
 
@@ -184,18 +184,20 @@ desktop 版は借方・貸方が同一科目でも登録をブロックしない
 
 | ストア | 主な state | 主なアクション |
 |-------|-----------|---------------|
-| `useFinancialStore` | `journalAccounts`, `journalEntries`, `regularJournalEntries` | 詳細は [`docs/api/specification.md`](../api/specification.md#ストアアクション一覧) |
+| `useFinancialStore` | `journalAccounts`, `regularJournalEntries`, `goals` | 詳細は [`docs/api/specification.md`](../api/specification.md#ストアアクション一覧) |
 | `useEventsStore` | `events` | `fetchEvents`, `addEvent`, `updateEvent`, `deleteEvent` |
 | `useAuthStore` | `session`, `userId`, `client` | `setSession`, `refreshSession`, `signOut` |
 
-`useFinancialStore` は `persist` ミドルウェアで `localStorage`（キー `financial-store`）に永続化される。
+`useFinancialStore` は `persist` ミドルウェアで `localStorage`（キー `financial-store`）に永続化される。`partialize` で永続化対象を `journalAccounts` / `regularJournalEntries` / `goals` の3つに限定している。
+
+カレンダー仕訳取得・「よく使う入力」サジェスト取得・BS/PL 取得は state を持たない読み取り専用クエリのため `useFinancialStore` のアクションではなく、`packages/shared/src/queries/`（`fetchCalendarJournalEntries` / `fetchFrequentEntrySets` / `fetchBalanceSheet` / `fetchProfitLoss`）から `@asset-simulator/shared` 経由で直接 import して呼ぶ。詳細は [`docs/api/specification.md`](../api/specification.md#純粋クエリ一覧packagessharedsrcqueries) を参照。
 
 ### 5.2 リフレッシュルール
 
 **ミューテーション後は変更したリソースのアクションだけを呼ぶ。** 広範囲な「全データ再取得」関数は存在しない。
 
-- 仕訳登録・更新後: `getJournalAccounts()`（残高が変わるため）を呼ぶ実装が多い（例: mobile `TransactionEntryCard`）
-- 定期取引実行後: `executeRegularJournalEntry`/`executeDueRegularJournalEntries` の内部で `getJournalAccounts()` + `getRegularJournalEntries()` を呼び直す
+- 仕訳登録・更新後: `fetchJournalAccounts()`（残高が変わるため）を呼ぶ実装が多い（例: mobile `TransactionEntryCard`）
+- 定期取引実行後: `executeRegularJournalEntry`/`executeDueRegularJournalEntries` の内部で `fetchJournalAccounts()` + `fetchRegularJournalEntries()` を呼び直す
 - イベント CRUD 後: `addEvent`/`updateEvent`/`deleteEvent` が自身で state を更新するため、`fetchEvents()` の再呼び出しは不要（コード内コメントにも明記）
 
 ### 5.3 初回データ取得（desktop / mobile 共通パターン）
@@ -205,10 +207,10 @@ App
 ├─ useEffect（認証監視）
 │   └─ refreshSession() → setSession() / onAuthStateChange → setSession()
 ├─ useEffect（session 依存, ref で一度だけ）
-│   └─ getJournalAccounts() + getRegularJournalEntries()（初回のみ）
+│   └─ fetchJournalAccounts() + fetchRegularJournalEntries()（初回のみ）
 │   └─ fetchEvents()（毎回）
 └─ 各タブ/カード
-    └─ ストアの state を購読、必要に応じて自身で個別データ（カレンダー月別データ・BS/PL 等）を取得
+    └─ ストアの state を購読、必要に応じて自身で個別データ（カレンダー月別データ・BS/PL 等、shared/queries の純粋クエリを直接呼ぶ）を取得
 ```
 
 - desktop: `activeTab` が `calendar`/`events` のときは `fetchEvents()` を再実行（実際のタブ ID は `transactions`/`events` などのため、この判定は現状ヒットしにくい実装になっている点に留意）
@@ -219,7 +221,7 @@ App
 ```
 TransactionEntryCard.registerEntry()
 └─ addJournalEntry()  … RPC create_journal_entry
-   └─ getJournalAccounts()  … 残高反映
+   └─ fetchJournalAccounts()  … 残高反映
       └─ onEntryAdded?.()  … App の entriesVersion をインクリメント
          └─ CalendarCard / PL・BS カードが再取得・再描画
 ```

--- a/mobile/app/src/App.tsx
+++ b/mobile/app/src/App.tsx
@@ -3,6 +3,8 @@ import {
   useAuthStore,
   useFinancialStore,
   useEventsStore,
+  fetchProfitLoss,
+  fetchBalanceSheet,
   formatDateLocal,
   filterSummaryIncludedRows,
 } from "@asset-simulator/shared";
@@ -68,10 +70,8 @@ function writeStoredMemo(userId: string, value: string) {
 function App() {
   const { session, client, setSession, refreshSession, signOut } = useAuthStore();
   const journalAccounts = useFinancialStore((s) => s.journalAccounts);
-  const getJournalAccounts = useFinancialStore((s) => s.getJournalAccounts);
-  const getRegularJournalEntries = useFinancialStore((s) => s.getRegularJournalEntries);
-  const getProfitLossStatementView = useFinancialStore((s) => s.getProfitLossStatementView);
-  const getBalanceSheetView = useFinancialStore((s) => s.getBalanceSheetView);
+  const fetchJournalAccounts = useFinancialStore((s) => s.fetchJournalAccounts);
+  const fetchRegularJournalEntries = useFinancialStore((s) => s.fetchRegularJournalEntries);
   const fetchEvents = useEventsStore((s) => s.fetchEvents);
 
   // 認証状態の監視
@@ -99,12 +99,12 @@ function App() {
   useEffect(() => {
     if (!session) return;
     if (!hasFetchedRef.current) {
-      getJournalAccounts();
-      getRegularJournalEntries();
+      fetchJournalAccounts();
+      fetchRegularJournalEntries();
       hasFetchedRef.current = true;
     }
     fetchEvents();
-  }, [session, fetchEvents, getJournalAccounts, getRegularJournalEntries]);
+  }, [session, fetchEvents, fetchJournalAccounts, fetchRegularJournalEntries]);
 
   const [activeTab, setActiveTab] = useState<TabId>("transaction");
   const [entryDialogDate, setEntryDialogDate] = useState<string | null>(null);
@@ -147,24 +147,24 @@ function App() {
   useEffect(() => {
     if (!session) return;
     let isMounted = true;
-    getProfitLossStatementView(plStartDate, plEndDate).then((rows) => {
+    fetchProfitLoss(plStartDate, plEndDate).then((rows) => {
       if (isMounted) setPlRows(rows);
     });
     return () => {
       isMounted = false;
     };
-  }, [session, plStartDate, plEndDate, entriesVersion, getProfitLossStatementView]);
+  }, [session, plStartDate, plEndDate, entriesVersion]);
 
   useEffect(() => {
     if (!session) return;
     let isMounted = true;
-    getBalanceSheetView(bsAsOfDate).then((rows) => {
+    fetchBalanceSheet(bsAsOfDate).then((rows) => {
       if (isMounted) setBsRows(rows);
     });
     return () => {
       isMounted = false;
     };
-  }, [session, bsAsOfDate, entriesVersion, getBalanceSheetView]);
+  }, [session, bsAsOfDate, entriesVersion]);
 
   const profit = useMemo(() => {
     const revenue = plRows.filter((r) => r.category === "Revenue").reduce((s, r) => s + r.sumAmount, 0);

--- a/mobile/app/src/CalendarCard.tsx
+++ b/mobile/app/src/CalendarCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo, useState } from "react";
-import { useFinancialStore, formatDateLocal } from "@asset-simulator/shared";
+import { useFinancialStore, fetchCalendarJournalEntries, formatDateLocal } from "@asset-simulator/shared";
 import type { CalendarJournalEntry } from "@asset-simulator/shared";
 import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
 import { CommonButton } from "@mobile-components/CommonButton";
@@ -38,7 +38,6 @@ function getWeekdayLabels() {
 }
 
 export default function CalendarCard({ onDateDoubleClick, onDateSelect, onEditEntry, refreshSignal, onEntryChanged }: CalendarCardProps) {
-  const getCalendarJournalEntries = useFinancialStore((s) => s.getCalendarJournalEntries);
   const deleteJournalEntry = useFinancialStore((s) => s.deleteJournalEntry);
   const journalAccounts = useFinancialStore((s) => s.journalAccounts);
 
@@ -55,19 +54,19 @@ export default function CalendarCard({ onDateDoubleClick, onDateSelect, onEditEn
   const monthEnd = fmt(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0));
 
   const refreshEntries = async () => {
-    const rows = await getCalendarJournalEntries(monthStart, monthEnd);
+    const rows = await fetchCalendarJournalEntries(monthStart, monthEnd);
     setEntries(rows);
   };
 
   useEffect(() => {
     let isMounted = true;
-    getCalendarJournalEntries(monthStart, monthEnd).then((rows) => {
+    fetchCalendarJournalEntries(monthStart, monthEnd).then((rows) => {
       if (isMounted) setEntries(rows);
     });
     return () => {
       isMounted = false;
     };
-  }, [monthStart, monthEnd, refreshSignal, getCalendarJournalEntries]);
+  }, [monthStart, monthEnd, refreshSignal]);
 
   const days = getMonthDays(currentMonth.getFullYear(), currentMonth.getMonth());
   const firstWeekday = currentMonth.getDay();

--- a/mobile/app/src/GoalCard.tsx
+++ b/mobile/app/src/GoalCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useFinancialStore, todayLocalString } from "@asset-simulator/shared";
+import { useFinancialStore, fetchProfitLoss, todayLocalString } from "@asset-simulator/shared";
 import type { Goal, GoalPeriod } from "@asset-simulator/shared";
 import type { PeriodRange } from "@mobile-components/periodSelector.utils";
 import { Card, CardBodyHead, CardBodyMain } from "@mobile-components/Card";
@@ -38,11 +38,10 @@ interface GoalCardProps {
 export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
   const journalAccounts = useFinancialStore((s) => s.journalAccounts);
   const goals = useFinancialStore((s) => s.goals);
-  const getGoals = useFinancialStore((s) => s.getGoals);
+  const fetchGoals = useFinancialStore((s) => s.fetchGoals);
   const addGoal = useFinancialStore((s) => s.addGoal);
   const updateGoal = useFinancialStore((s) => s.updateGoal);
   const deleteGoal = useFinancialStore((s) => s.deleteGoal);
-  const getProfitLossStatementView = useFinancialStore((s) => s.getProfitLossStatementView);
 
   const [isExpanded, setIsExpanded] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -53,8 +52,8 @@ export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
   const [actualByAccount, setActualByAccount] = useState<ActualByAccount>({ day: {}, month: {} });
 
   useEffect(() => {
-    getGoals();
-  }, [getGoals]);
+    fetchGoals();
+  }, [fetchGoals]);
 
   // 目標に対する実績支出（日次は当日分、月次はダッシュボードの月次指定期間分）を取得し、進捗表示に利用する
   useEffect(() => {
@@ -71,8 +70,8 @@ export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
     };
 
     Promise.all([
-      getProfitLossStatementView(today, today),
-      getProfitLossStatementView(monthRange.startDate, monthRange.endDate),
+      fetchProfitLoss(today, today),
+      fetchProfitLoss(monthRange.startDate, monthRange.endDate),
     ]).then(([dayRows, monthRows]) => {
       if (!isMounted) return;
       setActualByAccount({ day: toActualMap(dayRows), month: toActualMap(monthRows) });
@@ -81,7 +80,7 @@ export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
     return () => {
       isMounted = false;
     };
-  }, [goals, monthRange.startDate, monthRange.endDate, refreshSignal, getProfitLossStatementView]);
+  }, [goals, monthRange.startDate, monthRange.endDate, refreshSignal]);
 
   // 支出目標は費用科目に対して設定する
   const expenseAccountOptions = useMemo(

--- a/mobile/app/src/TransactionEntryCard.tsx
+++ b/mobile/app/src/TransactionEntryCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useFinancialStore, todayLocalString } from "@asset-simulator/shared";
+import { useFinancialStore, fetchFrequentEntrySets, todayLocalString } from "@asset-simulator/shared";
 import type { CalendarJournalEntry, FrequentEntrySet } from "@asset-simulator/shared";
 import { Card, CardBodyMain } from "@mobile-components/Card";
 import { DateInput } from "@mobile-components/DateInput";
@@ -27,8 +27,7 @@ export default function TransactionEntryCard({
   const journalAccounts = useFinancialStore((s) => s.journalAccounts);
   const addJournalEntry = useFinancialStore((s) => s.addJournalEntry);
   const updateJournalEntry = useFinancialStore((s) => s.updateJournalEntry);
-  const getJournalAccounts = useFinancialStore((s) => s.getJournalAccounts);
-  const getFrequentJournalEntrySets = useFinancialStore((s) => s.getFrequentJournalEntrySets);
+  const fetchJournalAccounts = useFinancialStore((s) => s.fetchJournalAccounts);
 
   const isEditMode = entry != null;
 
@@ -60,13 +59,13 @@ export default function TransactionEntryCard({
   useEffect(() => {
     if (isEditMode) return;
     let isMounted = true;
-    getFrequentJournalEntrySets().then((sets) => {
+    fetchFrequentEntrySets().then((sets) => {
       if (isMounted) setSuggestions(sets);
     });
     return () => {
       isMounted = false;
     };
-  }, [isEditMode, getFrequentJournalEntrySets]);
+  }, [isEditMode]);
 
   const applySuggestion = (suggestion: FrequentEntrySet) => {
     setDescription(suggestion.description);
@@ -107,7 +106,7 @@ export default function TransactionEntryCard({
     try {
       await addJournalEntry({ date, description, debitAccountId, creditAccountId, amount, user_id: "" });
       // 変更したリソースのみリフレッシュ（勘定科目の残高更新）
-      await getJournalAccounts();
+      await fetchJournalAccounts();
       onEntryAdded?.();
       setDescription("");
       setAmount(0);
@@ -136,7 +135,7 @@ export default function TransactionEntryCard({
         user_id: entry.userId,
       });
       // 変更したリソースのみリフレッシュ（勘定科目の残高更新）
-      await getJournalAccounts();
+      await fetchJournalAccounts();
       onEntryUpdated?.();
     } catch (error) {
       console.error("Failed to update journal entry:", error);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './stores/authStore';
 export * from './stores/financialStore';
 export * from './stores/eventsStore';
+export { fetchCalendarJournalEntries, fetchFrequentEntrySets, fetchBalanceSheet, fetchProfitLoss } from './queries';
 export { toCamelCase, toSnakeCase } from './utils/caseConvert';
 export { formatDateLocal, todayLocalString, adjustWeekendDate } from './utils/dateUtils';
 export type { HolidayAdjustment } from './utils/dateUtils';

--- a/packages/shared/src/queries/index.ts
+++ b/packages/shared/src/queries/index.ts
@@ -1,0 +1,2 @@
+export { fetchCalendarJournalEntries, fetchFrequentEntrySets, FREQUENT_ENTRY_LOOKBACK_COUNT } from './journalEntries';
+export { fetchBalanceSheet, fetchProfitLoss } from './reports';

--- a/packages/shared/src/queries/journalEntries.ts
+++ b/packages/shared/src/queries/journalEntries.ts
@@ -1,0 +1,52 @@
+// 仕訳エントリー関連の「取得のみ・state を持たない」純粋クエリ。
+// financialStore のミューテーション/キャッシュとは分離し、呼び出し側が直接 import して使う。
+import { toCamelCase } from '../utils/caseConvert';
+import { aggregateFrequentEntrySets } from '../utils/frequentEntries';
+import type { FrequentEntrySet } from '../utils/frequentEntries';
+import { CalendarJournalEntry } from '../types/common';
+import { useAuthStore, supabase } from '../stores/authStore';
+
+// 「よく使う取引入力値セット」の集計対象とする直近仕訳の件数
+export const FREQUENT_ENTRY_LOOKBACK_COUNT = 200;
+
+// カレンダー表示用VIEW `v_journal_entries_for_calendar` から仕訳を取得
+// 勘定科目名とカテゴリが事前に JOIN されているため、クライアント側の find() 検索が不要
+export async function fetchCalendarJournalEntries(startDate: string, endDate: string): Promise<CalendarJournalEntry[]> {
+  const { userId } = useAuthStore.getState();
+  if (!userId) return [];
+
+  try {
+    const { data, error } = await supabase
+      .from('v_journal_entries_for_calendar')
+      .select('*')
+      .eq('user_id', userId)
+      .gte('date', startDate)
+      .lte('date', endDate)
+      .order('date', { ascending: false });
+    if (error) throw error;
+    return toCamelCase(data || []) as CalendarJournalEntry[];
+  } catch (error) {
+    console.error('Failed to fetch calendar journal entries:', error);
+    return [];
+  }
+}
+
+// 直近の仕訳から「よく使う取引入力値セット」を集計して返す（取引入力画面のサジェスト用。state には保存しない）
+export async function fetchFrequentEntrySets(limit = 5): Promise<FrequentEntrySet[]> {
+  const { userId } = useAuthStore.getState();
+  if (!userId) return [];
+
+  try {
+    const { data, error } = await supabase
+      .from('journal_entries')
+      .select('date, description, debit_account_id, credit_account_id, amount')
+      .eq('user_id', userId)
+      .order('date', { ascending: false })
+      .limit(FREQUENT_ENTRY_LOOKBACK_COUNT);
+    if (error) throw error;
+    return aggregateFrequentEntrySets(toCamelCase(data || []), limit);
+  } catch (error) {
+    console.error('Failed to fetch frequent journal entry sets:', error);
+    return [];
+  }
+}

--- a/packages/shared/src/queries/reports.ts
+++ b/packages/shared/src/queries/reports.ts
@@ -1,0 +1,46 @@
+// 貸借対照表・損益計算書の「取得のみ・state を持たない」純粋クエリ（Supabase RPC 経由）。
+// financialStore のミューテーション/キャッシュとは分離し、呼び出し側が直接 import して使う。
+import { toCamelCase } from '../utils/caseConvert';
+import { formatDateLocal, todayLocalString } from '../utils/dateUtils';
+import { BalanceSheetView, ProfitLossView } from '../types/common';
+import { useAuthStore, supabase } from '../stores/authStore';
+
+// 貸借対照表 VIEW（RPC `fn_balance_sheet`）
+export async function fetchBalanceSheet(asOfDate?: string): Promise<BalanceSheetView[]> {
+  const { userId } = useAuthStore.getState();
+  if (!userId) return [];
+
+  try {
+    const asOfDateStr = asOfDate || todayLocalString();
+    const { data, error } = await supabase
+      .rpc('fn_balance_sheet', { p_end_date: asOfDateStr, p_user_id: userId });
+    if (error) throw error;
+    return toCamelCase(data || []) as BalanceSheetView[];
+  } catch (error) {
+    console.error('Error fetching balance sheet view:', error);
+    return [];
+  }
+}
+
+// 損益計算書 VIEW（RPC `fn_profit_loss`）
+export async function fetchProfitLoss(startDate?: string, endDate?: string): Promise<ProfitLossView[]> {
+  const { userId } = useAuthStore.getState();
+  if (!userId) return [];
+
+  try {
+    const today = new Date();
+    const defaultStart = formatDateLocal(new Date(today.getFullYear(), today.getMonth(), 1));
+    const defaultEnd = todayLocalString();
+    const { data, error } = await supabase
+      .rpc('fn_profit_loss', {
+        p_start_date: startDate || defaultStart,
+        p_end_date: endDate || defaultEnd,
+        p_user_id: userId,
+      });
+    if (error) throw error;
+    return toCamelCase(data || []) as ProfitLossView[];
+  } catch (error) {
+    console.error('Error fetching profit/loss statement view:', error);
+    return [];
+  }
+}

--- a/packages/shared/src/stores/financialStore.ts
+++ b/packages/shared/src/stores/financialStore.ts
@@ -2,16 +2,11 @@ import { create } from 'zustand';
 import type { StateCreator } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { toCamelCase, toSnakeCase } from '../utils/caseConvert';
-import { formatDateLocal, todayLocalString } from '../utils/dateUtils';
+import { todayLocalString } from '../utils/dateUtils';
 import { isExecutionDate } from '../utils/recurrence';
-import { aggregateFrequentEntrySets } from '../utils/frequentEntries';
-import type { FrequentEntrySet } from '../utils/frequentEntries';
 import {
   JournalAccount,
   JournalEntry,
-  CalendarJournalEntry,
-  BalanceSheetView,
-  ProfitLossView,
   RecurringTransaction,
   Goal,
 } from '../types/common';
@@ -22,18 +17,13 @@ import { useAuthStore, supabase } from './authStore';
 interface FinancialState {
   // Master Data
   journalAccounts: JournalAccount[]; // 勘定科目リスト
-  journalEntries: JournalEntry[];
   regularJournalEntries: RecurringTransaction[];
   goals: Goal[]; // 支出目標リスト
 
   // GET Actions
-  getJournalAccounts: () => Promise<JournalAccount[]>;
-  getCalendarJournalEntries: (startDate: string, endDate: string) => Promise<CalendarJournalEntry[]>; // カレンダー用VIEW
-  getFrequentJournalEntrySets: (limit?: number) => Promise<FrequentEntrySet[]>; // 取引入力サジェスト用
-  getRegularJournalEntries: () => Promise<RecurringTransaction[]>;
-  getGoals: () => Promise<Goal[]>;
-  getBalanceSheetView: (asOfDate?: string) => Promise<BalanceSheetView[]>;
-  getProfitLossStatementView: (startDate?: string, endDate?: string) => Promise<ProfitLossView[]>;
+  fetchJournalAccounts: () => Promise<JournalAccount[]>;
+  fetchRegularJournalEntries: () => Promise<RecurringTransaction[]>;
+  fetchGoals: () => Promise<Goal[]>;
 
   // CRUD Actions
   addJournalAccount: (account: Omit<JournalAccount, 'id'>) => Promise<void>;
@@ -51,9 +41,6 @@ interface FinancialState {
   executeRegularJournalEntry: (entry: RecurringTransaction) => Promise<void>; // 個別実行
   executeDueRegularJournalEntries: () => Promise<{executed: number, details: any[]}>; // 期限が来ている定期取引を実行
 }
-
-// 「よく使う取引入力値セット」の集計対象とする直近仕訳の件数
-const FREQUENT_ENTRY_LOOKBACK_COUNT = 200;
 
 // 定期取引の実行（仕訳挿入 + last_executed_date 更新）を行う共通処理。
 // executeRegularJournalEntry / executeDueRegularJournalEntries の両方から利用する。
@@ -97,7 +84,6 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
     if (!uid) {
       set({
         journalAccounts: [],
-        journalEntries: [],
         regularJournalEntries: [],
         goals: [],
       });
@@ -108,12 +94,11 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
   return ({
   // --- STATE ---
   journalAccounts: [],
-  journalEntries: [],
   regularJournalEntries: [],
   goals: [],
 
   // --- CRUD Actions ---
-  getJournalAccounts: async (): Promise<JournalAccount[]> => {
+  fetchJournalAccounts: async (): Promise<JournalAccount[]> => {
     const { userId } = useAuthStore.getState();
     if (!userId) return [];
 
@@ -134,49 +119,7 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
     }
   },
 
-  // カレンダー表示用VIEW `v_journal_entries_for_calendar` から仕訳を取得
-  // 勘定科目名とカテゴリが事前に JOIN されているため、クライアント側の find() 検索が不要
-  getCalendarJournalEntries: async (startDate: string, endDate: string): Promise<CalendarJournalEntry[]> => {
-    const { userId } = useAuthStore.getState();
-    if (!userId) return [];
-
-    try {
-      const { data, error } = await supabase
-        .from('v_journal_entries_for_calendar')
-        .select('*')
-        .eq('user_id', userId)
-        .gte('date', startDate)
-        .lte('date', endDate)
-        .order('date', { ascending: false });
-      if (error) throw error;
-      return toCamelCase(data || []) as CalendarJournalEntry[];
-    } catch (error) {
-      console.error('Failed to fetch calendar journal entries:', error);
-      return [];
-    }
-  },
-
-  // 直近の仕訳から「よく使う取引入力値セット」を集計して返す（取引入力画面のサジェスト用。state には保存しない）
-  getFrequentJournalEntrySets: async (limit = 5): Promise<FrequentEntrySet[]> => {
-    const { userId } = useAuthStore.getState();
-    if (!userId) return [];
-
-    try {
-      const { data, error } = await supabase
-        .from('journal_entries')
-        .select('date, description, debit_account_id, credit_account_id, amount')
-        .eq('user_id', userId)
-        .order('date', { ascending: false })
-        .limit(FREQUENT_ENTRY_LOOKBACK_COUNT);
-      if (error) throw error;
-      return aggregateFrequentEntrySets(toCamelCase(data || []), limit);
-    } catch (error) {
-      console.error('Failed to fetch frequent journal entry sets:', error);
-      return [];
-    }
-  },
-
-  getRegularJournalEntries: async (): Promise<RecurringTransaction[]> => {
+  fetchRegularJournalEntries: async (): Promise<RecurringTransaction[]> => {
     const { userId } = useAuthStore.getState();
     if (!userId) return [];
 
@@ -196,7 +139,7 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
     }
   },
 
-  getGoals: async (): Promise<Goal[]> => {
+  fetchGoals: async (): Promise<Goal[]> => {
     const { userId } = useAuthStore.getState();
     if (!userId) return [];
 
@@ -261,16 +204,6 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
         update_balances: true,
       });
       if (error) throw error;
-      const newEntry = toCamelCase({
-        id: entryId,
-        date: entry.date,
-        description: entry.description,
-        debit_account_id: entry.debitAccountId,
-        credit_account_id: entry.creditAccountId,
-        amount,
-        user_id: userId,
-      });
-      set(() => ({ journalEntries: [...get().journalEntries, newEntry] }));
     } catch (error) {
       console.error("Failed to add journal entry:", error);
     }
@@ -353,7 +286,7 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
     if (!userId) return;
 
     try {
-      const { data, error } = await supabase
+      const { error } = await supabase
         .from('journal_entries')
         .update({
           date: entry.date,
@@ -366,12 +299,6 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
         .eq('user_id', userId)
         .select();
       if (error) throw error;
-      if (data && data.length > 0) {
-        const updated = toCamelCase(data[0]);
-        set(() => ({
-          journalEntries: get().journalEntries.map((e) => e.id === updated.id ? updated : e),
-        }));
-      }
     } catch (error) {
       console.error("Failed to update journal entry:", error);
     }
@@ -451,9 +378,6 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
         .eq('id', entry.id)
         .eq('user_id', userId);
       if (error) throw error;
-      set(() => ({
-        journalEntries: get().journalEntries.filter((e) => e.id !== entry.id),
-      }));
     } catch (error) {
       console.error("Failed to delete journal entry:", error);
     }
@@ -518,8 +442,8 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
 
       await insertRecurringExecution(userId, dbEntry, today, entry.amount);
 
-      await get().getJournalAccounts();
-      await get().getRegularJournalEntries();
+      await get().fetchJournalAccounts();
+      await get().fetchRegularJournalEntries();
     } catch (error) {
       console.error("Failed to execute regular journal entry:", error);
     }
@@ -568,52 +492,13 @@ const financialStore: StateCreator<FinancialState> = (set, get) => {
         }
       }
 
-      await get().getJournalAccounts();
-      await get().getRegularJournalEntries();
+      await get().fetchJournalAccounts();
+      await get().fetchRegularJournalEntries();
 
       return { executed: executedEntries.length, details };
     } catch (error) {
       console.error("Failed to execute due regular journal entries:", error);
       throw error;
-    }
-  },
-
-  // --- VIEW Methods (Supabase RPC) ---
-  getBalanceSheetView: async (asOfDate?: string): Promise<BalanceSheetView[]> => {
-    const { userId } = useAuthStore.getState();
-    if (!userId) return [];
-
-    try {
-      const asOfDateStr = asOfDate || todayLocalString();
-      const { data, error } = await supabase
-        .rpc('fn_balance_sheet', { p_end_date: asOfDateStr, p_user_id: userId });
-      if (error) throw error;
-      return toCamelCase(data || []) as BalanceSheetView[];
-    } catch (error) {
-      console.error('Error fetching balance sheet view:', error);
-      return [];
-    }
-  },
-
-  getProfitLossStatementView: async (startDate?: string, endDate?: string): Promise<ProfitLossView[]> => {
-    const { userId } = useAuthStore.getState();
-    if (!userId) return [];
-
-    try {
-      const today = new Date();
-      const defaultStart = formatDateLocal(new Date(today.getFullYear(), today.getMonth(), 1));
-      const defaultEnd = todayLocalString();
-      const { data, error } = await supabase
-        .rpc('fn_profit_loss', {
-          p_start_date: startDate || defaultStart,
-          p_end_date: endDate || defaultEnd,
-          p_user_id: userId,
-        });
-      if (error) throw error;
-      return toCamelCase(data || []) as ProfitLossView[];
-    } catch (error) {
-      console.error('Error fetching profit/loss statement view:', error);
-      return [];
     }
   },
 
@@ -626,6 +511,12 @@ export const useFinancialStore = create<FinancialState>()(
     financialStore,
     {
       name: 'financial-store', // localStorage key
+      // 永続化対象を明示的に絞る（journalEntries 等の未使用 state を localStorage に残さない）
+      partialize: (state) => ({
+        journalAccounts: state.journalAccounts,
+        regularJournalEntries: state.regularJournalEntries,
+        goals: state.goals,
+      }),
     }
   )
 );


### PR DESCRIPTION
## 関連Issue

closes #144

## 変更概要

`useFinancialStore` の state / アクション境界を整理する動作不変のリファクタ。**Supabase へのクエリ内容（テーブル・VIEW・RPC 名・引数・フィルタ・order・limit・エラー時の戻り値）は一切変更していない。** 変えたのは関数の名前・置き場所・state の構成のみ。

### 1. state に書き込む取得系アクションを `fetchXxx` に改名

`getXxx` という名前だが実体は「Supabase から取得して state に書き込む」フェッチャーであり、getter に見えて誤解を招いていた。

- `getJournalAccounts` → `fetchJournalAccounts`
- `getRegularJournalEntries` → `fetchRegularJournalEntries`
- `getGoals` → `fetchGoals`

### 2. 純粋クエリを `packages/shared/src/queries/` へ分離

`set()` を一切呼ばない4つをストアから外し、モジュールスコープの素の async 関数として公開。呼び出し側は `@asset-simulator/shared` から直接 import する。

| 旧（ストアのアクション） | 新（素の関数） | 配置 |
|---|---|---|
| `getCalendarJournalEntries` | `fetchCalendarJournalEntries` | `queries/journalEntries.ts` |
| `getFrequentJournalEntrySets` | `fetchFrequentEntrySets` | `queries/journalEntries.ts` |
| `getBalanceSheetView` | `fetchBalanceSheet` | `queries/reports.ts` |
| `getProfitLossStatementView` | `fetchProfitLoss` | `queries/reports.ts` |

これにより「state を更新するもの＝ストアのアクション」「state を触らないもの＝素の関数」が import の形で区別できる。

なお BS/PL・カレンダーの取得方法は変更せず、引き続きサーバー側（RPC / VIEW）で集計する。JS 側集計に寄せると会計ロジックの真実が SQL と JS の2箇所になり、`journal_entries` 全件をクライアントに載せる必要も生じるため。

### 3. 未使用の `journalEntries` state を削除

どの UI からも読まれていないにもかかわらず、CRUD のたびに更新され `persist` で localStorage にも書かれ続けていた。state 宣言・初期値・ログアウト時クリア・`add`/`update`/`deleteJournalEntry` 内の `set()` を除去。アクション自体と Supabase 呼び出しは維持。

あわせて `persist` に `partialize` を追加し、永続化対象を `journalAccounts` / `regularJournalEntries` / `goals` の3つに明示（localStorage に残った古いキーを書き戻さないため）。

### 4. desktop の `useFinancialStore` をセレクタ形式に統一

セレクタなしの分割代入は無関係な state 変更でも再描画されるため、`mobile/app` と同じ1アクション1行のセレクタ形式に統一。リポジトリ全体で `useFinancialStore()` の分割代入はゼロになった。

`useEffect` の依存配列から外した関数参照は、いずれもストアのアクション（Zustand では identity 不変）かモジュールスコープ関数のため、発火タイミングは変わらない。

### 5. ドキュメント更新

`CLAUDE.md`（shared 分離ルール表に `queries/` を追加）、`docs/architecture/overview.md`、`docs/api/specification.md`、`docs/ui/specification.md`、`docs/database/schema.md`、`docs/test/scenarios.md`。

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない
- [x] 影響範囲の動作確認済み

### 検証結果

- `npx turbo run build --force` — 3/3 成功
- `@asset-simulator/shared` の Jest — 51/51 成功
- `mobile/` / `mobile/app/` の `tsc -b` — エラーなし
- 旧関数名・`journalEntries`・セレクタなし `useFinancialStore()` の残存 — grep でゼロ

### 既知の失敗（本 PR とは無関係）

`desktop#test` が `react-calendar` の ESM を Jest が transform できず失敗する（`SyntaxError: Cannot use import statement outside a module`）。本 PR の変更を stash して `main` の状態で実行しても同一のエラーが再現するため、既存の問題。別 Issue で対応するのが妥当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
