### PR TITLE
fix(全体): 旧形式の支出目標が残っていると画面が真っ白になる問題を修正 #148

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, lazy, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from '@mobile-components/ErrorBoundary'
 import { isMobileDevice } from './utils/deviceDetect'
 
 const App = isMobileDevice()
@@ -8,8 +9,10 @@ const App = isMobileDevice()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Suspense fallback={null}>
-      <App />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback={null}>
+        <App />
+      </Suspense>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,9 +8,9 @@
     "skipLibCheck": true,
     "paths": {
       "@asset-simulator/shared": ["../packages/shared/src/index.ts"],
-      "@web/*": ["../web/src/*"],
-      "@mobile/*": ["../web-new/playground/src/*"],
-      "@mobile-components/*": ["../web-new/src/components/*"]
+      "@web/*": ["../desktop/src/*"],
+      "@mobile/*": ["../mobile/app/src/*"],
+      "@mobile-components/*": ["../mobile/components/*"]
     }
   },
   "include": ["src"]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -86,6 +86,8 @@ alias は `client/vite.config.ts` で定義:
 
 **リフレッシュルール**: ミューテーション後は変更したリソースのアクション（`fetchJournalAccounts()` 等）だけを個別に呼ぶ。広範囲な「全データ再取得」関数は持たない。`financialStore` は `useAuthStore.subscribe` でログアウトを検知し、`userId` が空になったらキャッシュをクリアする。
 
+**永続データのスキーマ変更ルール**: `financialStore` の `persist` は `version` を持つ（現在 `1`）。永続化対象（`journalAccounts` / `regularJournalEntries` / `goals`）の型を破壊的に変更する場合は、必ず `version` を上げて `migrate` に変換処理を追加すること。既存利用者の localStorage には旧形式が残っており、変換しないとレンダリング時に例外が発生してアプリ全体が白画面になる（#148）。
+
 ## shared/queries
 
 `state` を持たない「取得のみ」の純粋クエリは `packages/shared/src/queries/` に置き、ストアのアクションとは別のモジュールスコープの async 関数として公開する（呼び出し側は `@asset-simulator/shared` から直接 import する）。

--- a/docs/test/scenarios.md
+++ b/docs/test/scenarios.md
@@ -55,6 +55,8 @@ npm test --workspace=packages/shared
 | `computeGoalProgress` | 複数科目の合計に対する達成率・残額を返すこと／超過時は `overBudget` と超過額を返すこと／目標金額 0 で 0 除算せず達成率 0 を返すこと |
 | `isSameAccountSet` | 順序が異なっても同一セットと判定すること／要素数・要素が異なれば `false` |
 | `formatGoalLabel` | `name` があればそれを使うこと／空なら対象科目名を連結すること／上限件数を超えたら「ほか N 件」に省略すること／対象科目が空の場合のフォールバック |
+| `migrateLegacyGoal` | 旧形式の `accountId`（単数）を `accountIds` 配列に変換すること／変換後に旧 `accountId` を残さないこと／現行形式はそのまま維持すること／どちらも無ければ空配列にすること |
+| 各関数の防御的挙動 | `accountIds` が未定義でも `sumGoalActual` / `computeGoalProgress` / `formatGoalLabel` / `isSameAccountSet` が例外を投げないこと（#148 の白画面再発防止） |
 
 ### 1.2 desktop のスモークテスト
 
@@ -155,6 +157,7 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 | 10 | ダイアログで対象科目を1件も選択していない | 「保存」を押す | バリデーションエラー（アラート表示）となり保存されない |
 | 11 | 複数科目の目標のうち1科目を、勘定科目管理から削除する | 勘定科目を削除 | `goal_accounts` が CASCADE で削除され対象科目から外れる。目標は残り、残りの科目の合計で集計される |
 | 12 | 対象科目が1件だけの目標の、その科目を削除する | 勘定科目を削除 | 対象科目が 0 件になるため `trg_goal_accounts_delete_orphan_goals` が目標自体を削除する |
+| 13 | #147 以前のアプリで目標を登録し、localStorage に旧形式（`accountId` 単数・`version` なし）が残っている | ログイン済みの同じブラウザで #148 以降のアプリを開く | 白画面にならず正常描画され、`persist` の `migrate` により `financial-store` が `version: 1` / `accountIds` 配列に変換される |
 
 ### 2.7 スケジュールイベント
 
@@ -214,3 +217,9 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 
 - **変更点**: `computePeriodRange`/`shiftPeriodRange` の月次終了日計算を「翌期間の（調整後）開始日の前日」に変更し、休日ずらし設定時の期間重複・欠落を解消
 - **確認手順**: `packages/shared/src/utils/__tests__/period.test.ts` の `#106 回帰テスト` を実行し、あわせてダッシュボードで開始日25日+休日前倒し/後倒しの設定にして前後の期間ボタンを連続操作し、表示範囲が重複・欠落しないことを目視確認する
+
+### 3.6 永続データのスキーマ変更と白画面（#148）
+
+- **変更点**: `financialStore` の `persist` に `version: 1` と `migrate` を追加し、#147 以前の目標（`accountId` 単数）を `accountIds` 配列へ変換するようにした。あわせて `goals.ts` の各関数を `accountIds` 未定義でも例外を投げないようにし、両エントリー（`client/src/main.tsx`・`mobile/app/src/main.tsx`）を `ErrorBoundary` で包んだ
+- **確認手順**: DevTools で `localStorage` の `financial-store` を旧形式（`{"state":{"goals":[{"id":"goal_1","accountId":"jacc_xxx","period":"month","amount":30000}]},"version":0}`）に書き換えてリロードし、白画面にならず目標が表示され、`version` が `1` に、目標が `accountIds` 配列に変換されることを確認する
+- **補足**: 永続化対象の型を破壊的に変更するときは必ず `version` を上げて `migrate` を追加すること（[`docs/architecture/overview.md`](../architecture/overview.md#状態管理) 参照）

--- a/docs/ui/specification.md
+++ b/docs/ui/specification.md
@@ -125,6 +125,7 @@ App (desktop/src/App.tsx)
 | `DataGrid<T>` | `DataGrid.tsx` | `data: T[]`, `columns: {label,key,width?,align?}[]`, `colorVariant?`(blue/red/gray)。ジェネリックなテーブル表示 |
 | `DateInput` | `DateInput.tsx` | `value`, `onChange`, `onBlur?`, `readOnly?`, `sizeVariant?`(S/M/L/Full), `fontSize?`。`min="2000-01-01"` `max="2100-12-31"` 固定 |
 | `Dialog` | `Dialog.tsx` | `isOpen`, `onClose`, `title?`, `children?`。`createPortal` で `document.body` に描画、Esc キーで閉じる |
+| `ErrorBoundary` | `ErrorBoundary.tsx` | `children`, `fallback?`。レンダリング中の例外を捕捉するクラスコンポーネント。`fallback` 未指定時は「再読み込み」と「保存データを削除して再読み込み」（`localStorage.clear()`）のボタン付きエラー画面を表示する。`client/src/main.tsx` と `mobile/app/src/main.tsx` の両エントリーでアプリ全体を包む |
 | `MultiSelectInput` | `MultiSelectInput.tsx` | `options: {label,value}[]`, `values: string[]`, `onChange`, `sizeVariant?`(S/M/L/Full。リストの最大高さ), `fontSize?`, `emptyMessage?`。チェックボックスによる複数選択（`select multiple` はモバイルで操作しにくいためリスト形式）。`onChange` は `options` の並び順で返す |
 | `NumericInput` | `NumericInput.tsx` | `value`, `unit?`, `min?`, `max?`, `error?`, `placeholder?`, `allowNegative?`（±ボタン表示）, `onBlur?`, `sizeVariant?`, `fontSize?`。ローカル文字列 state を持ち `onBlur` でのみ確定 |
 | `PanelButton` | `PanelButton.tsx` | `title`, `value`, `onClick`, `subText?`。金額サマリーの大きなボタン（純利益/純資産パネルなどで使用） |
@@ -190,6 +191,8 @@ desktop 版は借方・貸方が同一科目でも登録をブロックしない
 | `useAuthStore` | `session`, `userId`, `client` | `setSession`, `refreshSession`, `signOut` |
 
 `useFinancialStore` は `persist` ミドルウェアで `localStorage`（キー `financial-store`）に永続化される。`partialize` で永続化対象を `journalAccounts` / `regularJournalEntries` / `goals` の3つに限定している。
+
+永続データにはスキーマバージョン（現在 `version: 1`）を持たせている。**永続化対象の型を破壊的に変更する場合は必ず `version` を上げ、`migrate` に変換処理を追加すること。** 古い形式のまま復元されると、レンダリング中に例外が発生してアプリ全体が白画面になる（#148）。`version: 1` の `migrate` は #147 以前の目標（`accountId` 単数・`name` なし）を `accountIds: [accountId]` / `name: ''` に変換する（`migrateLegacyGoal`）。
 
 カレンダー仕訳取得・「よく使う入力」サジェスト取得・BS/PL 取得は state を持たない読み取り専用クエリのため `useFinancialStore` のアクションではなく、`packages/shared/src/queries/`（`fetchCalendarJournalEntries` / `fetchFrequentEntrySets` / `fetchBalanceSheet` / `fetchProfitLoss`）から `@asset-simulator/shared` 経由で直接 import して呼ぶ。詳細は [`docs/api/specification.md`](../api/specification.md#純粋クエリ一覧packagessharedsrcqueries) を参照。
 

--- a/mobile/.storybook/ErrorBoundary.stories.tsx
+++ b/mobile/.storybook/ErrorBoundary.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+
+// 描画時に必ず throw して、フォールバック画面をカタログ表示するための子コンポーネント
+function Exploding(): never {
+  throw new Error("Cannot read properties of undefined (reading 'reduce')");
+}
+
+const meta = {
+  title: "Components/ErrorBoundary",
+  component: ErrorBoundary,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ErrorBoundary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: <Exploding />,
+  },
+};
+
+export const WithCustomFallback: Story = {
+  args: {
+    children: <Exploding />,
+    fallback: <div style={{ padding: 24 }}>支出目標の表示に失敗しました。</div>,
+  },
+};
+
+export const NoError: Story = {
+  args: {
+    children: <div style={{ padding: 24 }}>正常に描画された子要素</div>,
+  },
+};

--- a/mobile/app/src/main.tsx
+++ b/mobile/app/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from '@mobile-components/ErrorBoundary'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/mobile/components/ErrorBoundary.tsx
+++ b/mobile/components/ErrorBoundary.tsx
@@ -1,0 +1,114 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** エラー時に表示する内容。未指定の場合は既定のフォールバック画面を表示する */
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  minHeight: "100vh",
+  padding: "1rem",
+  background: "#F3F4F6",
+  color: "#111827",
+  textAlign: "center",
+};
+
+/**
+ * レンダリング中の例外でアプリ全体が真っ白になるのを防ぐエラーバウンダリ。
+ * 想定外のデータ形状（例: 旧形式の永続データ）でクラッシュした場合でも、
+ * 再読み込み手段とキャッシュ削除手段を利用者に提示する。
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Unhandled rendering error:", error, errorInfo.componentStack);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  // 破損した永続キャッシュが原因のことがあるため、localStorage を消してから再読み込みする
+  private handleClearCache = () => {
+    try {
+      localStorage.clear();
+    } catch (error) {
+      console.error("Failed to clear localStorage:", error);
+    }
+    window.location.reload();
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback;
+
+    return (
+      <main style={containerStyle}>
+        <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}>
+          画面の表示中にエラーが発生しました
+        </h1>
+        <p style={{ fontSize: 14, color: "#6B7280", marginBottom: 24 }}>
+          再読み込みしても直らない場合は、保存データを削除してから再読み込みしてください。
+        </p>
+        <div style={{ display: "flex", gap: 12, marginBottom: 24 }}>
+          <button
+            onClick={this.handleReload}
+            style={{
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "none",
+              background: "#4F46E5",
+              color: "#FFFFFF",
+              fontSize: 14,
+              fontWeight: 600,
+            }}
+          >
+            再読み込み
+          </button>
+          <button
+            onClick={this.handleClearCache}
+            style={{
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "1px solid #D1D5DB",
+              background: "#FFFFFF",
+              color: "#374151",
+              fontSize: 14,
+              fontWeight: 600,
+            }}
+          >
+            保存データを削除して再読み込み
+          </button>
+        </div>
+        <pre
+          style={{
+            maxWidth: "100%",
+            overflowX: "auto",
+            fontSize: 12,
+            color: "#9CA3AF",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        >
+          {error.message}
+        </pre>
+      </main>
+    );
+  }
+}

--- a/packages/shared/src/stores/financialStore.ts
+++ b/packages/shared/src/stores/financialStore.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware';
 import { toCamelCase, toSnakeCase } from '../utils/caseConvert';
 import { todayLocalString } from '../utils/dateUtils';
 import { isExecutionDate } from '../utils/recurrence';
+import { migrateLegacyGoal } from '../utils/goals';
 import {
   JournalAccount,
   JournalEntry,
@@ -526,6 +527,16 @@ export const useFinancialStore = create<FinancialState>()(
     financialStore,
     {
       name: 'financial-store', // localStorage key
+      // #147 で Goal が accountId（単数）から accountIds（複数）に変わったため、
+      // 旧形式のまま復元して描画時に例外を起こさないようマイグレーションする
+      version: 1,
+      migrate: (persisted: any, version: number) => {
+        if (version >= 1) return persisted;
+        return {
+          ...persisted,
+          goals: (persisted?.goals ?? []).map(migrateLegacyGoal),
+        };
+      },
       // 永続化対象を明示的に絞る（journalEntries 等の未使用 state を localStorage に残さない）
       partialize: (state) => ({
         journalAccounts: state.journalAccounts,

--- a/packages/shared/src/utils/__tests__/goals.test.ts
+++ b/packages/shared/src/utils/__tests__/goals.test.ts
@@ -2,8 +2,18 @@ import {
   computeGoalProgress,
   formatGoalLabel,
   isSameAccountSet,
+  migrateLegacyGoal,
   sumGoalActual,
 } from '../goals';
+
+// #147 以前に localStorage へ保存された形式（accountId 単数・name なし）
+const legacyGoal = {
+  id: 'goal_1',
+  userId: 'u1',
+  accountId: 'jacc_food',
+  period: 'month' as const,
+  amount: 30000,
+};
 
 const actual = {
   jacc_food: 30000,
@@ -85,5 +95,66 @@ describe('formatGoalLabel', () => {
 
   it('対象科目が空の場合のフォールバック', () => {
     expect(formatGoalLabel({ name: '', accountIds: [] }, names)).toBe('(対象科目なし)');
+  });
+});
+
+describe('migrateLegacyGoal', () => {
+  it('旧形式の accountId を accountIds 配列に変換する', () => {
+    expect(migrateLegacyGoal(legacyGoal)).toEqual({
+      id: 'goal_1',
+      userId: 'u1',
+      name: '',
+      accountIds: ['jacc_food'],
+      period: 'month',
+      amount: 30000,
+    });
+  });
+
+  it('変換後に旧 accountId フィールドを残さない', () => {
+    expect(migrateLegacyGoal(legacyGoal)).not.toHaveProperty('accountId');
+  });
+
+  it('現行形式はそのまま維持する', () => {
+    const current = {
+      id: 'goal_2',
+      userId: 'u1',
+      name: '食まわり',
+      accountIds: ['jacc_food', 'jacc_eatout'],
+      period: 'month' as const,
+      amount: 50000,
+    };
+    expect(migrateLegacyGoal(current)).toEqual(current);
+  });
+
+  it('accountId も accountIds も無い場合は空配列にする', () => {
+    expect(migrateLegacyGoal({ id: 'goal_3', period: 'day', amount: 1000 }).accountIds).toEqual([]);
+  });
+});
+
+// 旧形式が migrate を経ずに復元されると画面が真っ白になっていた（#148）ため、
+// 各関数が accountIds 未定義でも例外を投げないことを保証する
+describe('accountIds が未定義でも例外を投げない', () => {
+  const brokenGoal = legacyGoal as unknown as { accountIds: string[]; amount: number; name: string };
+
+  it('sumGoalActual', () => {
+    expect(sumGoalActual(undefined as unknown as string[], actual)).toBe(0);
+  });
+
+  it('computeGoalProgress', () => {
+    expect(computeGoalProgress(brokenGoal, actual)).toEqual({
+      actual: 0,
+      percent: 0,
+      overBudget: false,
+      diff: 30000,
+    });
+  });
+
+  it('formatGoalLabel', () => {
+    expect(formatGoalLabel(brokenGoal, { jacc_food: '食費' })).toBe('(対象科目なし)');
+  });
+
+  it('isSameAccountSet', () => {
+    expect(isSameAccountSet(undefined as unknown as string[], [])).toBe(true);
+    expect(isSameAccountSet(undefined as unknown as string[], ['a'])).toBe(false);
   });
 });

--- a/packages/shared/src/utils/goals.ts
+++ b/packages/shared/src/utils/goals.ts
@@ -1,6 +1,29 @@
 import { Goal } from '../types/common';
 
 /**
+ * 目標の対象勘定科目 ID を安全に取り出す。
+ * localStorage に #147 以前の形式（`accountId` 単数）が残っている場合は
+ * `accountIds` が undefined になるため、フォールバックして例外を防ぐ。
+ */
+const toAccountIds = (value: string[] | undefined | null): string[] =>
+  Array.isArray(value) ? value : [];
+
+/**
+ * localStorage に残っている #147 以前の形式の支出目標を現行の形状に変換する。
+ * 旧形式は対象勘定科目を `accountId`（単数）で持ち、`name` を持たない。
+ * 既に現行形式のものはそのまま返す。
+ */
+export const migrateLegacyGoal = (goal: any): Goal => {
+  const accountIds = Array.isArray(goal?.accountIds)
+    ? goal.accountIds
+    : goal?.accountId
+      ? [goal.accountId]
+      : [];
+  const { accountId: _legacyAccountId, ...rest } = goal ?? {};
+  return { ...rest, name: goal?.name ?? '', accountIds } as Goal;
+};
+
+/**
  * 支出目標の進捗。目標に紐づく全勘定科目の実績を合計して算出する。
  */
 export interface GoalProgress {
@@ -17,7 +40,8 @@ export interface GoalProgress {
 export const sumGoalActual = (
   accountIds: string[],
   actualByAccount: Record<string, number>
-): number => accountIds.reduce((sum, id) => sum + (actualByAccount[id] ?? 0), 0);
+): number =>
+  toAccountIds(accountIds).reduce((sum, id) => sum + (actualByAccount[id] ?? 0), 0);
 
 /**
  * 目標の進捗（実績合計・達成率・残額/超過額）を算出する。
@@ -42,9 +66,11 @@ export const computeGoalProgress = (
  * 「同じ対象科目・同じ期間」の目標を二重登録させないための重複チェックに使う。
  */
 export const isSameAccountSet = (a: string[], b: string[]): boolean => {
-  if (a.length !== b.length) return false;
-  const setB = new Set(b);
-  return a.every((id) => setB.has(id));
+  const listA = toAccountIds(a);
+  const listB = toAccountIds(b);
+  if (listA.length !== listB.length) return false;
+  const setB = new Set(listB);
+  return listA.every((id) => setB.has(id));
 };
 
 /**
@@ -57,7 +83,7 @@ export const formatGoalLabel = (
   maxNames = 2
 ): string => {
   if (goal.name) return goal.name;
-  const names = goal.accountIds.map((id) => accountNameById[id] ?? id);
+  const names = toAccountIds(goal.accountIds).map((id) => accountNameById[id] ?? id);
   if (names.length === 0) return '(対象科目なし)';
   if (names.length <= maxNames) return names.join(' + ');
   return `${names.slice(0, maxNames).join(' + ')} ほか ${names.length - maxNames} 件`;


### PR DESCRIPTION
closes #148

## 原因

#147 で `Goal` が `accountId: string` から `accountIds: string[]`（+ `name`）に変わったが、`financialStore` の `persist` に `version` / `migrate` が無いため、localStorage キー `financial-store` に残った旧形式がそのまま復元されていた。

復元された旧形式は `accountIds` が `undefined` になり、`goals.ts` の各関数が無防備に `.reduce` / `.map` を呼んで例外になる。`GoalCard` はレンダリング中にこれらを呼び、アプリにエラーバウンダリが一つも無かったため React がツリー全体をアンマウントし、**画面が完全に真っ白**になっていた。

`mobile/app/src/App.tsx` の `if (!session) return <LoginScreen />` を通過した後にクラッシュするため、利用者からは「ログイン画面すら開かない」ように見える。

## 変更内容

| 変更 | 内容 |
|---|---|
| `packages/shared/src/stores/financialStore.ts` | `persist` に `version: 1` と `migrate` を追加。旧形式の目標を変換してから復元する |
| `packages/shared/src/utils/goals.ts` | `migrateLegacyGoal` を追加。`sumGoalActual` / `computeGoalProgress` / `formatGoalLabel` / `isSameAccountSet` が `accountIds` 未定義でも例外を投げないようにする |
| `mobile/components/ErrorBoundary.tsx` | 新規。レンダリング例外を捕捉し、「再読み込み」「保存データを削除して再読み込み」を提示する |
| `client/src/main.tsx` / `mobile/app/src/main.tsx` | 両エントリーでアプリ全体を `ErrorBoundary` で包む |
| `mobile/.storybook/ErrorBoundary.stories.tsx` | 新規。フォールバック画面のカタログ |
| `packages/shared/src/utils/__tests__/goals.test.ts` | マイグレーションと防御的挙動のテストを追加（64 → 72 件） |
| `docs/` | 永続データのスキーマ変更ルール、`ErrorBoundary`、テスト観点・回帰観点を追記 |

## 補足: `client/tsconfig.json` の paths 修正

`ErrorBoundary` を `@mobile-components/` から import するにあたり、`client/tsconfig.json` の `paths` が旧ディレクトリ名（`../web/src`, `../web-new/...`）のままで解決できないことが判明したため、`vite.config.ts` と同じ現行パス（`desktop/`, `mobile/app/`, `mobile/components/`）に揃えた。

これにより従来 alias 未解決で隠れていた desktop の型エラーが 1 件表面化したが、React 18/19 の型定義競合という別スコープの問題のため本 PR では扱わず、別 Issue に切り出す。CI（`npm run build:client` = `vite build`）は型検査を行わないため影響はない。

## 検証

**自動テスト**

- `packages/shared` jest: 5 suites / **72 件すべて pass**（新規 8 件）
- 型検査: `packages/shared` / `mobile` / `mobile/app` / `desktop` すべて 0 エラー
- `npm run build:client`: 成功

**ブラウザ実機確認**（Chrome / iPhone UA、ログイン済みセッションを注入）

localStorage の目標の形だけを変えた対照実験:

| 永続データ | 修正前 | 修正後 |
|---|---|---|
| 旧 `accountId`（`version: 0`） | `pageerror: Cannot read properties of undefined (reading 'reduce')` / `#root` 空 | エラーなし・正常描画。`version: 1` / `accountIds: ["jacc_food"]` に変換される |
| 新 `accountIds` | 正常描画 | 正常描画（変化なし） |

`npm run dev:mobile` と `vite build` + `vite preview`（本番と同じ経路）の両方で確認。

**エラーバウンダリ**: `goals` を配列でない値に壊した状態で、白画面ではなくフォールバック（「画面の表示中にエラーが発生しました」＋復旧ボタン＋`goals.map is not a function`）が表示されることを確認。

## Done条件

- [x] `persist` に `version` と `migrate` を追加し、旧 `accountId` を `accountIds: [accountId]`、`name` を `''` に変換する
- [x] `goals.ts` の各関数が `accountIds` 未定義でも例外を投げない
- [x] 上記のマイグレーションとフォールバックに対する自動テストを追加する
- [x] アプリ全体をエラーバウンダリで包み、レンダリングエラー時に白画面ではなくエラー表示になる
- [x] 旧形式データを localStorage に入れた状態でモバイルアプリが正常描画されることを確認する
- [x] `docs/` の関連記述を更新する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
