### PR TITLE
Supabase エラーを利用者向けの原因説明に変換する

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -106,6 +106,7 @@ alias は `client/vite.config.ts` で定義:
 | `period.ts` | `computePeriodRange` / `shiftPeriodRange`（週/月/年プリセットの期間計算）、`DEFAULT_PERIOD_SETTINGS` |
 | `recurrence.ts` | `isExecutionDate` / `getNextExecutionDate`（定期取引の実行日判定。daily/weekly/monthly/yearly/free に対応） |
 | `goals.ts` | `sumGoalActual` / `computeGoalProgress`（対象勘定科目の実績合計・達成率・残額の算出）、`isSameAccountSet`（対象科目セットの同一判定）、`formatGoalLabel`（目標の表示名生成） |
+| `supabaseError.ts` | `describeSupabaseError`（Supabase / PostgREST のエラーを利用者向けの原因説明に変換）、`isNetworkError`（通信断か否かの判定） |
 
 いずれも `packages/shared/src/index.ts` から named export され、`@asset-simulator/shared` としてインポート可能。`mobile/components/periodSelector.utils.ts` は `../../packages/shared/src/utils/period` を re-export するだけで、ロジックの実体は shared 側の一箇所に集約されている。
 

--- a/docs/test/scenarios.md
+++ b/docs/test/scenarios.md
@@ -58,6 +58,13 @@ npm test --workspace=packages/shared
 | `migrateLegacyGoal` | 旧形式の `accountId`（単数）を `accountIds` 配列に変換すること／変換後に旧 `accountId` を残さないこと／現行形式はそのまま維持すること／どちらも無ければ空配列にすること |
 | 各関数の防御的挙動 | `accountIds` が未定義でも `sumGoalActual` / `computeGoalProgress` / `formatGoalLabel` / `isSameAccountSet` が例外を投げないこと（#148 の白画面再発防止） |
 
+#### supabaseError.test.ts
+
+| 対象関数 | 観点 |
+|---------|------|
+| `isNetworkError` | supabase-js が fetch 失敗時に詰めるメッセージ（`Failed to fetch` / `NetworkError` / `Load failed`）を通信エラーと判定すること／サーバーから返ったエラー（`code` を持つ）は通信エラーとしないこと |
+| `describeSupabaseError` | 通信断のときだけ通信環境の確認を促すこと／`PGRST202`・`PGRST205`・`PGRST200`・`42883`・`42P01` はマイグレーション未適用の可能性を示すこと／`23503` は勘定科目の再読み込みを促すこと／`42501`・`PGRST301` は再ログインを促すこと／未知のコードはサーバーのメッセージとコードをそのまま見せること／メッセージが取れない場合もフォールバック文言を返すこと |
+
 ### 1.2 desktop のスモークテスト
 
 `desktop/src/App.test.tsx`（React Testing Library）。ヘッダー文言「会計＆資産シミュレーター」が描画されることのみを確認する簡易テスト。
@@ -158,6 +165,8 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 | 11 | 複数科目の目標のうち1科目を、勘定科目管理から削除する | 勘定科目を削除 | `goal_accounts` が CASCADE で削除され対象科目から外れる。目標は残り、残りの科目の合計で集計される |
 | 12 | 対象科目が1件だけの目標の、その科目を削除する | 勘定科目を削除 | 対象科目が 0 件になるため `trg_goal_accounts_delete_orphan_goals` が目標自体を削除する |
 | 13 | #147 以前のアプリで目標を登録し、localStorage に旧形式（`accountId` 単数・`version` なし）が残っている | ログイン済みの同じブラウザで #148 以降のアプリを開く | 白画面にならず正常描画され、`persist` の `migrate` により `financial-store` が `version: 1` / `accountIds` 配列に変換される |
+| 14 | リモート DB に `20260811000000_goals_multi_account.sql` が未適用（`save_goal` / `goal_accounts` が無い） | 目標を保存する | 「支出目標の保存に失敗しました。サーバー側にテーブルまたは関数がありません。DB のマイグレーションが未適用の可能性があります。（PGRST202）」と表示され、原因が画面から切り分けられる |
+| 15 | 機内モード等でオフライン | 目標を保存する | 「〜通信に失敗しました。通信環境を確認してもう一度お試しください。」と表示される（サーバーエラーと文言が区別される） |
 
 ### 2.7 スケジュールイベント
 
@@ -223,3 +232,9 @@ Given/When/Then 形式。特記のない限り desktop・mobile 双方で確認�
 - **変更点**: `financialStore` の `persist` に `version: 1` と `migrate` を追加し、#147 以前の目標（`accountId` 単数）を `accountIds` 配列へ変換するようにした。あわせて `goals.ts` の各関数を `accountIds` 未定義でも例外を投げないようにし、両エントリー（`client/src/main.tsx`・`mobile/app/src/main.tsx`）を `ErrorBoundary` で包んだ
 - **確認手順**: DevTools で `localStorage` の `financial-store` を旧形式（`{"state":{"goals":[{"id":"goal_1","accountId":"jacc_xxx","period":"month","amount":30000}]},"version":0}`）に書き換えてリロードし、白画面にならず目標が表示され、`version` が `1` に、目標が `accountIds` 配列に変換されることを確認する
 - **補足**: 永続化対象の型を破壊的に変更するときは必ず `version` を上げて `migrate` を追加すること（[`docs/architecture/overview.md`](../architecture/overview.md#状態管理) 参照）
+
+### 3.7 保存失敗の原因が画面から分からない問題
+
+- **変更点**: `GoalCard` の保存・削除失敗時のアラートが常に「通信を確認してください」だったため、実際の原因（RPC 未作成・権限不足・制約違反）が利用者にもログにも残らなかった。`describeSupabaseError`（`packages/shared/src/utils/supabaseError.ts`）で Supabase のエラーコードを利用者向けの原因説明に変換して表示するようにした
+- **確認手順**: 上記 2.6.1 の手動シナリオ 14・15 を実施する。ローカルスタックで再現する場合は `supabase db reset` 後に `DROP FUNCTION public.save_goal(uuid, text, text, text, numeric, text[]);` を実行してから目標を保存する
+- **補足**: マイグレーションのリモート反映は手動運用（[`docs/database/development_policy.md`](../database/development_policy.md) 6章）。`goals` 系のように新規 RPC・テーブルを伴う変更をマージしたら、`supabase db push --linked` を実行するまで本番では保存が失敗する

--- a/docs/ui/specification.md
+++ b/docs/ui/specification.md
@@ -110,7 +110,7 @@ App (desktop/src/App.tsx)
 | `BalanceSheetCard` | `BalanceSheetCard.tsx` | 資産・負債・純資産の明細サマリーリスト（基準日プリセット: 今日/今月末/先月末） | なし（`rows` は props） |
 | `RecurringTransactionCard` | `RecurringTransactionCard.tsx` | 定期取引の一覧・追加（ダイアログ）・実行・削除・期限到来分一括実行 | `addRegularJournalEntry`, `deleteRegularJournalEntry`, `executeRegularJournalEntry`, `executeDueRegularJournalEntries` |
 | `AccountMasterCard` | `AccountMasterCard.tsx` | 勘定科目の追加・一覧・**削除**（desktop の勘定科目管理は編集のみで削除なし） | `addJournalAccount`, `deleteJournalAccount` |
-| `GoalCard` | `GoalCard.tsx` | **複数の費用科目の合計**に対する期間（日次/月次）ごとの支出目標の設定（ダイアログ: 目標名（任意）・費用科目の複数選択（`MultiSelectInput`）・期間・金額）・一覧・進捗表示（対象科目一覧・対象期間・達成率%・残額/超過額・実績合計との比較バー）・編集・削除（確認ダイアログあり）。同一の対象科目セット・期間の目標が既にある場合は新規追加せず既存を更新する（`isSameAccountSet` で判定）。実績は対象科目の合計（`computeGoalProgress`）、表示名は `name` 未入力時に対象科目名から生成（`formatGoalLabel`）。月次の対象期間は props の `monthRange`（ダッシュボードの月次指定期間と同期、`App` が導出）、日次は当日。`refreshSignal` の変化で実績を再取得。`transaction` タブと `pl-bs` タブの両方から利用可能 | `fetchGoals`, `addGoal`, `updateGoal`, `deleteGoal`（アクション）, `fetchProfitLoss`（純粋クエリ、直接 import、実績取得） |
+| `GoalCard` | `GoalCard.tsx` | **複数の費用科目の合計**に対する期間（日次/月次）ごとの支出目標の設定（ダイアログ: 目標名（任意）・費用科目の複数選択（`MultiSelectInput`）・期間・金額）・一覧・進捗表示（対象科目一覧・対象期間・達成率%・残額/超過額・実績合計との比較バー）・編集・削除（確認ダイアログあり）。同一の対象科目セット・期間の目標が既にある場合は新規追加せず既存を更新する（`isSameAccountSet` で判定）。実績は対象科目の合計（`computeGoalProgress`）、表示名は `name` 未入力時に対象科目名から生成（`formatGoalLabel`）。月次の対象期間は props の `monthRange`（ダッシュボードの月次指定期間と同期、`App` が導出）、日次は当日。`refreshSignal` の変化で実績を再取得。`transaction` タブと `pl-bs` タブの両方から利用可能。保存・削除に失敗した場合は `describeSupabaseError` でエラーコードを原因説明に変換して表示する（通信断のときのみ通信環境の確認を促す） | `fetchGoals`, `addGoal`, `updateGoal`, `deleteGoal`（アクション）, `fetchProfitLoss`（純粋クエリ、直接 import、実績取得） |
 
 モバイル版には勘定科目の「編集」機能はない（追加・削除のみ）。desktop 版には「削除」機能がない（追加・編集のみ）。
 

--- a/mobile/app/src/GoalCard.tsx
+++ b/mobile/app/src/GoalCard.tsx
@@ -6,6 +6,7 @@ import {
   computeGoalProgress,
   formatGoalLabel,
   isSameAccountSet,
+  describeSupabaseError,
 } from "@asset-simulator/shared";
 import type { Goal, GoalPeriod } from "@asset-simulator/shared";
 import type { PeriodRange } from "@mobile-components/periodSelector.utils";
@@ -147,7 +148,7 @@ export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
       closeDialog();
     } catch (error) {
       console.error("Failed to save goal:", error);
-      alert("支出目標の保存に失敗しました。通信を確認してください。");
+      alert(`支出目標の保存に失敗しました。${describeSupabaseError(error)}`);
     } finally {
       setBusy(false);
     }
@@ -159,7 +160,7 @@ export function GoalCard({ monthRange, refreshSignal }: GoalCardProps) {
       await deleteGoal(goal);
     } catch (error) {
       console.error("Failed to delete goal:", error);
-      alert("支出目標の削除に失敗しました。通信を確認してください。");
+      alert(`支出目標の削除に失敗しました。${describeSupabaseError(error)}`);
     }
   };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export {
     formatGoalLabel,
 } from './utils/goals';
 export type { GoalProgress } from './utils/goals';
+export { describeSupabaseError, isNetworkError } from './utils/supabaseError';
 export type {
     Account,
     CreditCard,

--- a/packages/shared/src/utils/__tests__/supabaseError.test.ts
+++ b/packages/shared/src/utils/__tests__/supabaseError.test.ts
@@ -1,0 +1,61 @@
+import { describeSupabaseError, isNetworkError } from '../supabaseError';
+
+describe('isNetworkError', () => {
+  it('supabase-js が fetch 失敗時に詰めるメッセージを通信エラーと判定する', () => {
+    expect(isNetworkError({ message: 'TypeError: Failed to fetch' })).toBe(true);
+    expect(isNetworkError({ message: 'NetworkError when attempting to fetch resource.' })).toBe(true);
+    expect(isNetworkError(new TypeError('Load failed'))).toBe(true);
+  });
+
+  it('サーバーから返ったエラーは通信エラーとしない', () => {
+    expect(isNetworkError({ code: 'PGRST202', message: 'Could not find the function' })).toBe(false);
+  });
+});
+
+describe('describeSupabaseError', () => {
+  it('通信断のときだけ通信環境の確認を促す', () => {
+    expect(describeSupabaseError({ message: 'TypeError: Failed to fetch' })).toContain('通信環境');
+  });
+
+  it('RPC・テーブルが見つからない場合はマイグレーション未適用の可能性を示す', () => {
+    // save_goal がリモート DB に存在しない場合に PostgREST が返すコード
+    const message = describeSupabaseError({
+      code: 'PGRST202',
+      message: 'Could not find the function public.save_goal(...) in the schema cache',
+    });
+    expect(message).toContain('マイグレーションが未適用');
+    expect(message).toContain('PGRST202');
+    expect(message).not.toContain('通信環境');
+
+    expect(describeSupabaseError({ code: '42P01', message: 'relation does not exist' })).toContain(
+      'マイグレーションが未適用'
+    );
+  });
+
+  it('外部キー違反は勘定科目の再読み込みを促す', () => {
+    expect(describeSupabaseError({ code: '23503', message: 'violates foreign key constraint' })).toContain(
+      '対象の勘定科目が見つかりません'
+    );
+  });
+
+  it('RLS で弾かれた場合は再ログインを促す', () => {
+    expect(describeSupabaseError({ code: '42501', message: 'permission denied' })).toContain('権限がありません');
+  });
+
+  it('未知のコードはサーバーのメッセージとコードをそのまま見せる', () => {
+    expect(describeSupabaseError({ code: 'P0001', message: '対象勘定科目が指定されていません' })).toBe(
+      '対象勘定科目が指定されていません（P0001）'
+    );
+  });
+
+  it('コードを持たない素の Error はメッセージをそのまま見せる', () => {
+    expect(describeSupabaseError(new Error('対象勘定科目が指定されていません'))).toBe(
+      '対象勘定科目が指定されていません'
+    );
+  });
+
+  it('メッセージが取れない場合でも文言を返す', () => {
+    expect(describeSupabaseError(undefined)).toContain('原因不明');
+    expect(describeSupabaseError({})).toContain('原因不明');
+  });
+});

--- a/packages/shared/src/utils/supabaseError.ts
+++ b/packages/shared/src/utils/supabaseError.ts
@@ -1,0 +1,72 @@
+/**
+ * Supabase（PostgREST / PostgreSQL）から返るエラーを、利用者向けの原因説明に変換する。
+ *
+ * ストアのアクションは失敗を `console.error` に出すだけで UI へは詳細を渡していなかったため、
+ * 画面には常に「通信を確認してください」と表示され、実際の原因（RPC 未作成・権限不足・
+ * 制約違反など）が利用者にもログにも残らなかった。原因を切り分けられるようにするための共通処理。
+ */
+
+/** Supabase のエラーオブジェクト（`PostgrestError`）と、素の `Error` の共通部分 */
+interface SupabaseErrorLike {
+  message?: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+}
+
+/** fetch 自体が失敗したときに supabase-js が詰めるメッセージ（ブラウザごとに文言が異なる） */
+const NETWORK_MESSAGE_PATTERNS = [
+  /failed to fetch/i,
+  /networkerror/i,
+  /network request failed/i,
+  /load failed/i,
+];
+
+const NETWORK_CAUSE = '通信に失敗しました。通信環境を確認してもう一度お試しください。';
+
+/**
+ * スキーマがリモート DB へ未適用のときに返るコード。
+ * PGRST202/PGRST205/PGRST200 は PostgREST のスキーマキャッシュ由来、
+ * 42883/42P01 は Postgres 本体由来。
+ */
+const MIGRATION_CAUSE =
+  'サーバー側にテーブルまたは関数がありません。DB のマイグレーションが未適用の可能性があります。';
+
+/** エラーコードごとの利用者向け説明。ここに無いコードはサーバーのメッセージをそのまま見せる */
+const CAUSE_BY_CODE: Record<string, string> = {
+  PGRST202: MIGRATION_CAUSE, // RPC 関数がスキーマキャッシュに無い
+  PGRST205: MIGRATION_CAUSE, // テーブルがスキーマキャッシュに無い
+  PGRST200: MIGRATION_CAUSE, // 埋め込み取得の関連（外部キー）が見つからない
+  '42883': MIGRATION_CAUSE, // undefined_function
+  '42P01': MIGRATION_CAUSE, // undefined_table
+  PGRST301: '認証の有効期限が切れています。再ログインしてください。',
+  '42501': 'この操作を行う権限がありません。再ログインしてください。',
+  '23503': '対象の勘定科目が見つかりません。画面を再読み込みしてから設定し直してください。',
+  '23505': '同じ内容が既に登録されています。',
+  '23514': '入力値がサーバー側の制約を満たしていません。',
+};
+
+const toErrorLike = (error: unknown): SupabaseErrorLike => {
+  if (typeof error === 'object' && error !== null) return error as SupabaseErrorLike;
+  return { message: String(error ?? '') };
+};
+
+/** fetch 到達前・通信断によるエラーか */
+export const isNetworkError = (error: unknown): boolean => {
+  const message = toErrorLike(error).message ?? '';
+  return NETWORK_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
+};
+
+/**
+ * エラーの原因を 1 文で説明する。UI では「〜に失敗しました。」に続けて表示する想定。
+ * 既知のコードは日本語の説明に、未知のコードはサーバーのメッセージにコードを添えて返す。
+ */
+export const describeSupabaseError = (error: unknown): string => {
+  if (isNetworkError(error)) return NETWORK_CAUSE;
+
+  const { code, message } = toErrorLike(error);
+  const known = code ? CAUSE_BY_CODE[code] : undefined;
+  if (known) return `${known}（${code}）`;
+  if (message) return code ? `${message}（${code}）` : message;
+  return '原因不明のエラーが発生しました。時間をおいて再度お試しください。';
+};


### PR DESCRIPTION
## 関連Issue

closes #

## 変更概要

Supabase（PostgREST / PostgreSQL）から返るエラーを、利用者向けの原因説明に変換する共通処理 `describeSupabaseError` を実装しました。

これまで `GoalCard` の保存・削除失敗時は常に「通信を確認してください」と表示され、実際の原因（RPC 未作成・権限不足・制約違反など）が利用者にもログにも残りませんでした。エラーコードを判定して以下のように分類し、画面から原因を切り分けられるようにしました：

- **通信エラー** (`Failed to fetch` など): 通信環境の確認を促す
- **マイグレーション未適用** (`PGRST202`, `42P01` など): DB マイグレーション未適用の可能性を示す
- **権限不足** (`42501`, `PGRST301`): 再ログインを促す
- **外部キー違反** (`23503`): 対象リソースの再読み込みを促す
- **その他**: サーバーのメッセージとコードをそのまま表示

### 実装内容

- `packages/shared/src/utils/supabaseError.ts` — エラー判定・変換関数
  - `isNetworkError()`: fetch 失敗による通信エラーか判定
  - `describeSupabaseError()`: エラーコードを利用者向け説明に変換
- `packages/shared/src/utils/__tests__/supabaseError.test.ts` — ユニットテスト（11 ケース）
- `mobile/app/src/GoalCard.tsx` — エラーメッセージを `describeSupabaseError()` で変換
- ドキュメント更新
  - `docs/test/scenarios.md`: テストシナリオ追加
  - `docs/architecture/overview.md`: shared/utils に `supabaseError` を追記
  - `docs/ui/specification.md`: `GoalCard` の説明を更新

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない
- [x] 影響範囲の動作確認済み（ユニットテスト 11 ケース全て通過）

https://claude.ai/code/session_01AmyvjQwu4exLxd88s4A7ca