### PR TITLE
ci(DB): マイグレーションのリモート反映を GitHub Actions で自動化 #152

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -1,0 +1,63 @@
+name: Apply Supabase migrations
+
+# クライアント（deploy-client.yml）は main への push で自動デプロイされるのに対し、
+# DB は手動反映のままだったため、新しいクライアントが古いスキーマを叩く時間帯が生まれていた。
+# migrations の追加を main に入れた時点で、リモート DB へも自動で反映する。
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - '.github/workflows/deploy-supabase.yml'
+  workflow_dispatch:
+
+# DB への適用は巻き戻せないため、同時実行を禁止して直列に流す（実行中のジョブはキャンセルしない）
+concurrency:
+  group: supabase-db-push
+  cancel-in-progress: false
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    # 承認フローを挟みたくなった場合は、リポジトリ設定で production environment に
+    # required reviewers を設定するだけで有効になる
+    environment: production
+    env:
+      # supabase CLI が参照する。link 時のパスワード入力プロンプトもこれで省略される
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # シークレット未登録のまま動かすと link の失敗理由が分かりにくいため、先に明示的に落とす
+      - name: Check required secrets
+        shell: bash
+        run: |
+          for name in SUPABASE_ACCESS_TOKEN SUPABASE_PROJECT_ID SUPABASE_DB_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Secret $name is not configured. See docs/database/development_policy.md"
+              exit 1
+            fi
+          done
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to the remote project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      # 「これから何が適用されるか」を残す。失敗時の切り分けはこのログが起点になる
+      - name: Show pending migrations
+        run: supabase migration list --linked
+
+      - name: Apply migrations
+        run: supabase db push --linked
+
+      # 適用後の Local/Remote の一致を確認する。失敗しても結果を残したいので always
+      - name: Show applied migrations
+        if: always()
+        run: supabase migration list --linked

--- a/docs/database/development_policy.md
+++ b/docs/database/development_policy.md
@@ -201,12 +201,43 @@ supabase functions serve myos --env-file <env-file>
 6. **ドキュメント更新**: `docs/database/schema.md`・`er_diagram.puml`・
    `docs/api/specification.md` を変更内容に合わせて更新
 7. **PR 作成 → レビュー → マージ**（schemas/ と migrations/ の両方が PR に含まれること）
-8. **リモート反映**: マージ後に `supabase db push --linked` を実行（当面は手動運用。
-   将来的に GitHub Actions での自動化を検討）
+8. **リモート反映**: マージ時に GitHub Actions（`.github/workflows/deploy-supabase.yml`）が
+   `supabase db push --linked` を実行する（→ 6.1 節）。手動実行は不要
 
 ```
-Issue → branch → schemas/ 編集 → db diff -f で migration 生成 → db reset で検証 → PR → merge → db push
+Issue → branch → schemas/ 編集 → db diff -f で migration 生成 → db reset で検証 → PR → merge → Actions が db push
 ```
+
+### 6.1 リモート反映の自動化（GitHub Actions）
+
+`main` に `supabase/migrations/**` または `supabase/config.toml` の変更が入ると、
+`Apply Supabase migrations` ワークフローが起動して未適用のマイグレーションを本番へ反映する。
+
+| 項目 | 内容 |
+|------|------|
+| ワークフロー | `.github/workflows/deploy-supabase.yml` |
+| 起動条件 | `main` への push（`supabase/migrations/**`・`supabase/config.toml` 変更時）、および `workflow_dispatch` による手動実行 |
+| 実行内容 | `supabase link` → `supabase migration list --linked`（適用前後の状態をログに記録）→ `supabase db push --linked` |
+| 同時実行 | `concurrency: supabase-db-push` で直列化（DB への適用は巻き戻せないため、実行中のジョブはキャンセルしない） |
+| environment | `production`。承認を挟みたい場合はリポジトリ設定で required reviewers を追加する |
+
+**必要なシークレット**（リポジトリの Settings → Secrets and variables → Actions に登録。未登録の場合はワークフローが冒頭で明示的に失敗する）:
+
+| シークレット | 取得場所 |
+|-------------|---------|
+| `SUPABASE_ACCESS_TOKEN` | Supabase ダッシュボード → Account → Access Tokens |
+| `SUPABASE_PROJECT_ID` | プロジェクトの project-ref（ダッシュボード URL の `/project/<ref>` 部分） |
+| `SUPABASE_DB_PASSWORD` | プロジェクト作成時の DB パスワード（Settings → Database でリセット可能） |
+
+注意点:
+
+- 対象は**本番プロジェクトのみ**。ステージングへの反映は当面ローカルからの `supabase db push` で行う
+- `supabase db push` は「最後に適用されたバージョンより新しい」マイグレーションのみを適用する。
+  過去のタイムスタンプのファイルを後から追加した場合は適用対象にならないため、
+  マイグレーションのファイル名は必ず現在時刻で採番する（→ 7 章）
+- クライアント（`deploy-client.yml`）と DB のワークフローは独立して走る。
+  破壊的なスキーマ変更を含む場合は、旧クライアントが一時的に新スキーマを叩くことを前提に、
+  後方互換のある手順（カラム追加 → クライアント更新 → 旧カラム削除）に分割する
 
 ## 7. スキーマ・マイグレーション規約
 
@@ -254,6 +285,9 @@ supabase db diff --linked   # 差分なし = リポジトリとリモートが�
 
 - 差分が検出された場合は、原因（未 push のマイグレーション or ダッシュボード直接変更）を
   特定してから作業を開始する
+- リモート反映は自動化されている（→ 6.1 節）ため、`未 push のマイグレーション` は
+  「Actions が失敗したまま放置されている」ケースを指す。
+  該当ワークフロー（`Apply Supabase migrations`）の最新実行が成功しているかをあわせて確認する
 
 ## 9. セキュリティ・コミット規約
 


### PR DESCRIPTION
## 関連Issue

closes #152

## 変更概要

クライアント（`deploy-client.yml`）は `main` への push で Cloudflare Pages に自動デプロイされる一方、DB のリモート反映はマージ後の手動 `supabase db push --linked` に依存していた。この非対称のため「PR はマージ済みだが本番 DB は古いまま」という状態が構造的に生まれ、新しいクライアントが古いスキーマを叩くことになる（#146/#147 の `goal_accounts` / `save_goal` が未反映だと、モバイルの支出目標の保存が PostgREST の `PGRST202` で失敗する）。

### `.github/workflows/deploy-supabase.yml`（新規）

| 項目 | 内容 |
|------|------|
| 起動条件 | `main` への push（`supabase/migrations/**`・`supabase/config.toml` 変更時）＋ `workflow_dispatch` |
| 実行内容 | シークレット存在チェック → `supabase link` → `supabase migration list --linked`（適用前）→ `supabase db push --linked` → `supabase migration list --linked`（適用後、`if: always()`） |
| 同時実行 | `concurrency: supabase-db-push`。DB への適用は巻き戻せないため `cancel-in-progress: false` で実行中のジョブは止めない |
| environment | `production`。承認フローを挟みたくなったら、リポジトリ設定で required reviewers を追加するだけで有効になる |

適用前後の `migration list` をログに残しているので、「何が適用されたか」「どこで止まったか」が Actions のログだけで追える。シークレット未登録のまま起動した場合は `link` に到達する前に `::error::` で停止し、参照すべき docs のパスを出す。

### `docs/database/development_policy.md`

- 6章 手順8「マージ後に手動で `db push`（将来的に Actions での自動化を検討）」→ Actions による自動反映に更新
- 6.1 節を新設: ワークフローの仕様、必要なシークレット（`SUPABASE_ACCESS_TOKEN` / `SUPABASE_PROJECT_ID` / `SUPABASE_DB_PASSWORD`）と取得場所、注意点（本番のみ対象・ファイル名は現在時刻で採番・破壊的変更は後方互換の手順に分割）
- 8章 ドリフト検知に、「未 push のマイグレーション」＝「Actions が失敗したまま放置」を疑う旨を追記

## マージ後に必要な作業（管理者）

ワークフローを追加しただけでは動きません。リポジトリの Settings → Secrets and variables → Actions に以下を登録してください。

| シークレット | 取得場所 |
|-------------|---------|
| `SUPABASE_ACCESS_TOKEN` | Supabase ダッシュボード → Account → Access Tokens |
| `SUPABASE_PROJECT_ID` | プロジェクトの project-ref（ダッシュボード URL の `/project/<ref>` 部分） |
| `SUPABASE_DB_PASSWORD` | プロジェクト作成時の DB パスワード（Settings → Database でリセット可能） |

登録後、`workflow_dispatch` で手動実行して `migration list` の Local / Remote が一致することを確認するのが最初の動作確認になります。

## スコープ外（必要なら別 Issue）

- ステージングプロジェクトへの自動反映（当面はローカルからの `db push`）
- PR 時点での検証（`supabase start` → `db reset` でマイグレーションが baseline から通ることの確認、`supabase db diff` による `schemas/` と `migrations/` の乖離検知）

## 確認項目

- [x] Done条件をすべて満たしている
- [x] 型エラー・lintエラーがない（YAML パース・埋め込みシェルの構文チェック実施。アプリコードの変更なし）
- [ ] 影響範囲の動作確認済み（シークレット登録後に `workflow_dispatch` で実行して確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmyvjQwu4exLxd88s4A7ca


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmyvjQwu4exLxd88s4A7ca)_